### PR TITLE
Fix for bug preventing new module file creation

### DIFF
--- a/templates/sw-module.lua.j2
+++ b/templates/sw-module.lua.j2
@@ -3,7 +3,7 @@ help(
 {{ item.help_text }}
 ]])
 
-{% if item.base %}
+{% if item.base is defined %}
 local base = "{{ item.base }}"
 {% else %}
 local base = pathJoin("{{soft_dir}}", "{{ item.dir }}")


### PR DESCRIPTION
sw-module.lua.j2 contains code that assumes the `base` variable
has been supplied in the task being executed.

This means that the `else` in the template for a default base
is never executed and makes setting a base mandatory.

The change allows `base` not to be set, and a default used
in the template.
