### PR TITLE
Added a note about sw-installer user in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,11 @@ You need to manually download some packages that require license agreements.  Se
 
 By default software will be installed to /software.  So, if you want this to be on a separate mount, set that up before running ansible.
 
-So far this has only been developed on ubuntu 14.04
+On your target host(s), you must create a user sw-installer in the sudo group.
+
+    server:~$ sudo adduser --ingroup sudo sw-installer
+
+So far this has only been developed on Ubuntu 14.04
 
 Example to run
 --

--- a/main.yml
+++ b/main.yml
@@ -55,6 +55,7 @@
     - include: tasks/ngsutils.yml tags=ngsutils version=0.5.7
     - include: tasks/qiime.yml tags=qiime version=1.9.1
     - include: tasks/bbmap.yml tags=bbmap version=35.43
+    - include: tasks/fastqc.yml tags=fastqc version=0.11.4
 
     - include: tasks/macs2.yml tags=macs2 version=2.1.0.20140616
     - include: tasks/cutadapt.yml tags=cutadapt version=1.8

--- a/tasks/common-packages.yml
+++ b/tasks/common-packages.yml
@@ -6,6 +6,7 @@
   with_items:
     - mosh
     - tmux
+    - byobu
     - lua5.2
     - liblua5.2-dev
     - lua-filesystem
@@ -14,6 +15,7 @@
     - git
     - tcl
     - zsh
+    - vim
     - r-base-core
     - curl
     - htop

--- a/tasks/fastqc.yml
+++ b/tasks/fastqc.yml
@@ -1,0 +1,31 @@
+- name: Download FastQC
+  get_url:
+    url=http://www.bioinformatics.babraham.ac.uk/projects/fastqc/fastqc_v{{version}}.zip
+    dest={{ source_dir }}/fastqc_v{{ version }}.zip
+
+- name: Uncompress FastQC
+  unarchive:
+    src={{ source_dir }}/fastqc_v{{ version }}.zip
+    dest={{ soft_dir }}
+    copy=no
+    mode=0644
+    creates={{ soft_dir }}/FastQC/fastqc
+
+- name: Move FastQC to a version specific directory
+  command: mv {{ soft_dir }}/FastQC {{ soft_dir }}/FastQC-{{ version }}
+
+- file: path="{{ soft_dir }}/FastQC-{{ version }}/fastqc" mode="a+x"
+- file: dest="{{ modules_dir }}/bio/fastqc" state=directory mode=0755
+
+- name: FastQC module definition
+  template:
+    src: templates/sw-module.lua.j2
+    dest: "{{ modules_dir }}/bio/fastqc/{{ version }}.lua"
+    owner: root
+    mode: 0644
+  with_items:
+    - dir: 'FastQC-{{ version }}'
+      skip_bin: true
+      help_text: 'A quality control application for high throughput sequence data'
+
+


### PR DESCRIPTION
Also added byobu and 'proper' vim to the common base packages. The default vim-tiny that comes with Ubuntu is a nightmare to use.
