### PR TITLE
Change order of tasks so that sw-installer is created first

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,10 +9,6 @@ You need to manually download some packages that require license agreements.  Se
 
 By default software will be installed to /software.  So, if you want this to be on a separate mount, set that up before running ansible.
 
-On your target host(s), you must create a user sw-installer in the sudo group.
-
-    server:~$ sudo adduser --ingroup sudo sw-installer
-
 So far this has only been developed on Ubuntu 14.04
 
 Example to run

--- a/README.md
+++ b/README.md
@@ -9,7 +9,11 @@ You need to manually download some packages that require license agreements.  Se
 
 By default software will be installed to /software.  So, if you want this to be on a separate mount, set that up before running ansible.
 
-So far this has only been developed on ubuntu 14.04
+On your target host(s), you must create a user sw-installer in the sudo group.
+
+    server:~$ sudo adduser --ingroup sudo sw-installer
+
+So far this has only been developed on Ubuntu 14.04
 
 Example to run
 --

--- a/main.yml
+++ b/main.yml
@@ -7,7 +7,13 @@
     - brew_dir: /software/linuxbrew
     - ref_dir: /references
 
+  pre_tasks:
+    - name: Create sw-installer user
+      user: name=sw-installer comment="Software install user" group=adm
+
   tasks:
+    - include: tasks/linuxbrew.yml tags=linuxbrew
+
     - include: tasks/cran-r.yml
     - include: tasks/common-packages.yml tags=common
     - include: tasks/zsh.yml
@@ -15,8 +21,6 @@
     - include: tasks/java.yml 
     - include: tasks/java-link.yml tags=java-link
     - include: tasks/r-packages.yml
-
-    - include: tasks/linuxbrew.yml tags=linuxbrew
 
     - include: tasks/SPAdes.yml tags=spades version=3.6.0
     - include: tasks/bwa.yml tags=bwa

--- a/tasks/common-packages.yml
+++ b/tasks/common-packages.yml
@@ -6,6 +6,7 @@
   with_items:
     - mosh
     - tmux
+    - byobu
     - lua5.2
     - liblua5.2-dev
     - lua-filesystem
@@ -14,6 +15,7 @@
     - git
     - tcl
     - zsh
+    - vim
     - r-base-core
     - curl
     - htop

--- a/tasks/linuxbrew.yml
+++ b/tasks/linuxbrew.yml
@@ -1,7 +1,4 @@
 
-- name: Create sw-installer user
-  user: name=sw-installer comment="Software install user" group=adm
-
 - file: path={{brew_dir}} owner=sw-installer state=directory mode=0755
 
 - name: Clone Linuxbrew


### PR DESCRIPTION
Also added byobu and 'proper' vim to the common base packages. The default vim-tiny that comes with Ubuntu is a nightmare to use.
