### PR TITLE
Add task to install Rstudio Server daily via downloaded deb.

### DIFF
--- a/main.yml
+++ b/main.yml
@@ -48,7 +48,8 @@
     - include: tasks/bamutil.yml tags=bamutil version=1.0.13
     - include: tasks/bamstats.yml tags=bamstats version=1.25
     - include: tasks/trimmomatic.yml tags=trimmomatic version=0.33
-    - include: tasks/rstudio-server.yml tags=rstudio version=0.98.1103-amd64
+    # - include: tasks/rstudio-server.yml tags=rstudio version=0.98.1103-amd64
+    - include: tasks/rstudio-server-daily.yml tags=rstudio version=0.99.752-amd64
     - include: tasks/rna-seqc.yml tags=rna-seqc version=1.1.8
     - include: tasks/big-data-script.yml tags=big-data-script version=0.9999c
     - include: tasks/rseqc.yml tags=rseqc version=2.6.2

--- a/tasks/rstudio-server-daily.yml
+++ b/tasks/rstudio-server-daily.yml
@@ -1,0 +1,13 @@
+- name: Install packages
+  apt: pkg={{item}} state=present
+  with_items:
+    - gdebi-core
+    - libapparmor1
+
+- name: Download Rstudio server daily
+  get_url:
+    url=https://s3.amazonaws.com/rstudio-dailybuilds/rstudio-server-{{version}}.deb
+    dest={{source_dir}}/rstudio-server-{{version}}.deb
+
+- name: Install Rstudio server daily
+  shell: gdebi -n {{source_dir}}/rstudio-server-{{version}}.deb


### PR DESCRIPTION
This will replace the installed 'stable' package.

Other alternatives to have both in parallel would be to:
- Install Rstudio Server from source as a module: https://github.com/rstudio/rstudio
- Install Rstudio in a Docker container
- Install the dpkg in a schroot/chroot as a module, or extraced by dpkg -x rstudio.deb /software/modules/rstudio ?
- Update and use the homebrew/science/rstudio-server recipe to use daily, installed as a module
