### PR TITLE
Update versions of BLAST, IGV and GATK to current as at January 2016

### DIFF
--- a/main.yml
+++ b/main.yml
@@ -33,7 +33,7 @@
     - include: tasks/tophat.yml tags=tophat version=2.0.13
     - include: tasks/ncbi-blast.yml tags=ncbi-blast version=2.3.0
     - include: tasks/vcftools.yml tags=vcftools version=0.1.12b
-    - include: tasks/igvtools.yml tags=igvtools version=2.3.52
+    - include: tasks/igvtools.yml tags=igvtools version=2.3.67
     - include: tasks/igv.yml tags=igv version=2.3.52
     - include: tasks/gatk.yml tags=gatk version=3.3-0
     - include: tasks/bowtie.yml tags=bowtie1 version=1.1.1

--- a/main.yml
+++ b/main.yml
@@ -35,7 +35,7 @@
     - include: tasks/vcftools.yml tags=vcftools version=0.1.12b
     - include: tasks/igvtools.yml tags=igvtools version=2.3.67
     - include: tasks/igv.yml tags=igv version=2.3.67
-    - include: tasks/gatk.yml tags=gatk version=3.3-0
+    - include: tasks/gatk.yml tags=gatk version=3.5
     - include: tasks/bowtie.yml tags=bowtie1 version=1.1.1
     - include: tasks/bowtie2.yml tags=bowtie2 version=2.2.5
     - include: tasks/trinity.yml tags=trinity version=2.0.6

--- a/main.yml
+++ b/main.yml
@@ -31,7 +31,7 @@
     - include: tasks/bcftools.yml tags=bcftools version=1.2
     - include: tasks/cufflinks.yml tags=cufflinks version=2.2.1
     - include: tasks/tophat.yml tags=tophat version=2.0.13
-    - include: tasks/ncbi-blast.yml tags=ncbi-blast version=2.2.31
+    - include: tasks/ncbi-blast.yml tags=ncbi-blast version=2.3.0
     - include: tasks/vcftools.yml tags=vcftools version=0.1.12b
     - include: tasks/igvtools.yml tags=igvtools version=2.3.52
     - include: tasks/igv.yml tags=igv version=2.3.52

--- a/main.yml
+++ b/main.yml
@@ -34,7 +34,7 @@
     - include: tasks/ncbi-blast.yml tags=ncbi-blast version=2.3.0
     - include: tasks/vcftools.yml tags=vcftools version=0.1.12b
     - include: tasks/igvtools.yml tags=igvtools version=2.3.67
-    - include: tasks/igv.yml tags=igv version=2.3.52
+    - include: tasks/igv.yml tags=igv version=2.3.67
     - include: tasks/gatk.yml tags=gatk version=3.3-0
     - include: tasks/bowtie.yml tags=bowtie1 version=1.1.1
     - include: tasks/bowtie2.yml tags=bowtie2 version=2.2.5


### PR DESCRIPTION
This is what I needed to update to get bio-ansible to work in January 2016.

(I also needed to include r-base-core manually. apt-get complained that this package wasn't authenticated, and I needed to manually confirm I wanted to install it.)
