### PR TITLE
Add apt key for CRAN repo.

### DIFF
--- a/tasks/STAR.yml
+++ b/tasks/STAR.yml
@@ -3,6 +3,7 @@
   git: repo=https://github.com/alexdobin/STAR
        dest={{source_dir}}/STAR-{{version}}
        version=STAR_{{version}}
+       update=yes
 
 - name: Install STAR
   shell: cd {{ source_dir }}/STAR-{{version}}/bin/Linux_x86_64_static; mkdir -p "{{ soft_dir }}/STAR-{{version}}/bin" && cp STAR STARlong "{{ soft_dir }}/STAR-{{version}}/bin"

--- a/tasks/common-packages.yml
+++ b/tasks/common-packages.yml
@@ -42,3 +42,4 @@
     - texlive-latex-recommended
     - texlive-fonts-recommended
     - libzmq3-dev
+    - libncurses5-dev

--- a/tasks/common-packages.yml
+++ b/tasks/common-packages.yml
@@ -11,6 +11,7 @@
     - liblua5.2-dev
     - lua-filesystem
     - lua-posix
+    - build-essential
     - gcc
     - git
     - tcl

--- a/tasks/cran-r.yml
+++ b/tasks/cran-r.yml
@@ -1,5 +1,7 @@
+- name: Adding key for CRAN apt repository
+  apt_key: keyserver=keyserver.ubuntu.com id=E084DAB9 state=present
 
-- name: Adding apt repo
+- name: Adding apt repo for CRAN
   apt_repository: repo='deb http://cran.ms.unimelb.edu.au/bin/linux/ubuntu trusty/' state=present
 
 

--- a/tasks/gatk.yml
+++ b/tasks/gatk.yml
@@ -1,32 +1,42 @@
 
+- stat: path=tarballs/GenomeAnalysisTK-{{version}}.tar.bz2
+  register: gatktarball
+
+- debug: msg="Skipping installation of GATK - tarballs/GenomeAnalysisTK-{{version}}.tar.bz2 not found."
+  when: not gatktarball.stat.exists
+
 # Create a directory for extraction
 - file: dest="{{ soft_dir }}/GenomeAnalysisTK-{{version}}" state=directory mode=0755
+  when: gatktarball.stat.exists
 
 - name: Uncompress GATK
-  unarchive: 
+  unarchive:
     src: tarballs/GenomeAnalysisTK-{{version}}.tar.bz2
     dest: "{{ soft_dir }}/GenomeAnalysisTK-{{version}}"
     copy: yes
     creates: "{{ soft_dir }}/GenomeAnalysisTK-{{version}}/GenomeAnalysisTK.jar"
+  when: gatktarball.stat.exists
 
 - name: GATK wrapper script
   template:
     src: templates/java-wrapper.sh.j2
     dest: "{{ soft_dir }}/GenomeAnalysisTK-{{version}}/gatk"
-    owner: root 
+    owner: root
     mode: 0755
   with_items:
     - { jar: '{{ soft_dir }}/GenomeAnalysisTK-{{version}}/GenomeAnalysisTK.jar' }
+  when: gatktarball.stat.exists
 
 - file: dest="{{modules_dir}}/bio/gatk" state=directory mode=0755
+  when: gatktarball.stat.exists
 
 - name: GATK module definition
-  template: 
-    src: templates/sw-module.lua.j2 
+  template:
+    src: templates/sw-module.lua.j2
     dest: "{{ modules_dir }}/bio/gatk/{{version}}.lua"
-    owner: root 
+    owner: root
     mode: 0644
   with_items:
     - { help_text: 'The Genome Analysis Toolkit or GATK', dir: 'GenomeAnalysisTK-{{version}}', skip_bin: true }
-
+  when: gatktarball.stat.exists
 

--- a/tasks/igv.yml
+++ b/tasks/igv.yml
@@ -1,4 +1,7 @@
 
+- stat: path=tarballs/IGV_{{version}}.zip
+  register: igvzip
+
 # Check if it has been uncompressed.  The "creates" in the next section should do this, but it
 # seems to copy up the tarball anyway
 - stat: path={{ soft_dir}}/IGV_{{version}}/igv.sh
@@ -10,7 +13,10 @@
     dest={{ soft_dir }}
     copy=yes
     creates={{ soft_dir}}/IGV_{{version}}/igv.sh
-  when: not igv.stat.exists
+  when: not igv.stat.exists and igvzip.stat.exists
+
+- debug: msg="Didn't find tarballs/IGV_{{version}}.zip - not installing IGV"
+  when: not igvzip.stat.exists
 
 - file: dest="{{modules_dir}}/bio/igv" state=directory mode=0755
 

--- a/tasks/igvtools.yml
+++ b/tasks/igvtools.yml
@@ -2,6 +2,9 @@
 # Ensure the unarchive directory exists (the zip file has no version info)
 - file: dest="{{ soft_dir }}/IGVTools-{{version}}" state=directory mode=0755
 
+- stat: path=tarballs/igvtools_{{version}}.zip
+  register: igvtoolszip
+
 # Check if it has been uncompressed.  The "creates" in the next section should do this, but it
 # seems to copy up the tarball anyway
 - stat: path={{ soft_dir }}/IGVTools-{{version}}/IGVTools/igvtools
@@ -13,7 +16,10 @@
     dest={{ soft_dir }}/IGVTools-{{version}}
     copy=yes
     creates={{ soft_dir }}/IGVTools-{{version}}/IGVTools/igvtools
-  when: not igvtools.stat.exists
+  when: not igvtools.stat.exists and igvtoolszip.stat.exists
+
+- debug: msg="Didn't find tarballs/igvtools_{{version}}.zip - not installing igvtools"
+  when: not igvtoolszip.stat.exists
 
 - file: dest="{{modules_dir}}/bio/igvtools" state=directory mode=0755
 


### PR DESCRIPTION
Add apt-key for the CRAN repo. Installing packages in tasks/common-packages.yml fails otherwise.

Add the libncurses5-dev and build-essential (for g++) packages so that samtools and vcftools will compile. 

Skip IGV, igvtools and GATK install if archives aren't already manually downloaded.
