### PR TITLE
Download IGV and igvtools automatically.

### DIFF
--- a/main.yml
+++ b/main.yml
@@ -33,8 +33,8 @@
     - include: tasks/tophat.yml tags=tophat version=2.0.13
     - include: tasks/ncbi-blast.yml tags=ncbi-blast version=2.3.0
     - include: tasks/vcftools.yml tags=vcftools version=0.1.12b
-    - include: tasks/igvtools.yml tags=igvtools version=2.3.67
-    - include: tasks/igv.yml tags=igv version=2.3.67
+    - include: tasks/igvtools.yml tags=igvtools version=2.3.72
+    - include: tasks/igv.yml tags=igv version=2.3.72
     - include: tasks/gatk.yml tags=gatk version=3.5
     - include: tasks/bowtie.yml tags=bowtie1 version=1.1.1
     - include: tasks/bowtie2.yml tags=bowtie2 version=2.2.5

--- a/tarballs/README
+++ b/tarballs/README
@@ -1,11 +1,9 @@
 You need to manually download packages:
 
-http://www.broadinstitute.org/software/igv/download
-  IGV_2.3.42.zip
-  igvtools_2.3.42.zip
-
 https://www.broadinstitute.org/gatk/download/auth?package=GATK
   GenomeAnalysisTK-3.3-0.tar.bz2
 
-
+IGV and igvtools are automatically downloaded, however you should go here:
+  http://www.broadinstitute.org/software/igv/download
+and create and account, accept the license
 

--- a/tasks/igv.yml
+++ b/tasks/igv.yml
@@ -1,4 +1,9 @@
 
+- name: Download IGV - you should register here https://www.broadinstitute.org/software/igv/?q=registration and agree with the license terms (LGPL, http://www.opensource.org/licenses/lgpl-2.1.php)
+  get_url:
+    url=http://data.broadinstitute.org/igv/projects/downloads/IGV_{{version}}.zip
+    dest=tarballs/IGV_{{version}}.zip
+
 - stat: path=tarballs/IGV_{{version}}.zip
   register: igvzip
 

--- a/tasks/igvtools.yml
+++ b/tasks/igvtools.yml
@@ -1,4 +1,9 @@
 
+- name: Download igvtools - you should register here https://www.broadinstitute.org/software/igv/?q=registration and agree with the license terms (LGPL, http://www.opensource.org/licenses/lgpl-2.1.php)
+  get_url:
+    url=http://data.broadinstitute.org/igv/projects/downloads/igvtools_{{version}}.zip
+    dest=tarballs/igvtools_{{version}}.zip
+
 # Ensure the unarchive directory exists (the zip file has no version info)
 - file: dest="{{ soft_dir }}/IGVTools-{{version}}" state=directory mode=0755
 


### PR DESCRIPTION
This patch allows IGV and igvtools to be downloaded automatically. The license is LGPL - the registration page is purely for stats tracking. A debug message and README note was added to encourage users to register.

Also bumps IGV and igvtools to the latest version.
