### PR TITLE
Add Perl CPAN dependencies to make prokka install happy.

### DIFF
--- a/tasks/prokka.yml
+++ b/tasks/prokka.yml
@@ -1,8 +1,10 @@
 
 - name: Install prokka dependencies
-  cpanm: name=Bio::Perl
-
-- cpanm: name=XML::Simple
+  cpanm: name={{item}}
+  with_items:
+    - LWP::UserAgent
+    - XML::Simple
+    - Bio::Perl
 
 - include: brew_package.yml brew_name='homebrew/science/prokka' lmod_name='prokka'
 


### PR DESCRIPTION
Unsure why Bio::Perl wasn't happily resolving it's own dependencies, but this works for me on a vanilla Ubuntu 14.04 image now anyhow.
