### PR TITLE
Add retries and longer timeouts to all get_url operations

### DIFF
--- a/main.yml
+++ b/main.yml
@@ -22,7 +22,7 @@
     - include: tasks/java-link.yml tags=java-link
     - include: tasks/r-packages.yml
 
-    - include: tasks/SPAdes.yml tags=spades version=3.6.0
+    - include: tasks/SPAdes.yml tags=spades version=3.7.0
     - include: tasks/bwa.yml tags=bwa
     - include: tasks/STAR.yml tags=star version=2.4.2a
     - include: tasks/picard.yml tags=picard version=1.129

--- a/main.yml
+++ b/main.yml
@@ -56,7 +56,7 @@
     - include: tasks/artemis.yml tags=artemis version=16.0.0
     - include: tasks/mummer.yml tags=mummer version=3.23
     - include: tasks/abacas.yml tags=abacas version=1.3.1
-    - include: tasks/snippy.yml tags=snippy version=2.5
+    - include: tasks/snippy.yml tags=snippy version=2.9
     - include: tasks/ngsutils.yml tags=ngsutils version=0.5.7
     - include: tasks/qiime.yml tags=qiime version=1.9.1
     - include: tasks/bbmap.yml tags=bbmap version=35.43

--- a/main.yml
+++ b/main.yml
@@ -33,7 +33,7 @@
     - include: tasks/tophat.yml tags=tophat version=2.0.13
     - include: tasks/ncbi-blast.yml tags=ncbi-blast version=2.3.0
     - include: tasks/vcftools.yml tags=vcftools version=0.1.12b
-    - include: tasks/igvtools.yml tags=igvtools version=2.3.52
+    - include: tasks/igvtools.yml tags=igvtools version=2.3.67
     - include: tasks/igv.yml tags=igv version=2.3.52
     - include: tasks/gatk.yml tags=gatk version=3.3-0
     - include: tasks/bowtie.yml tags=bowtie1 version=1.1.1

--- a/main.yml
+++ b/main.yml
@@ -61,6 +61,7 @@
     - include: tasks/qiime.yml tags=qiime version=1.9.1
     - include: tasks/bbmap.yml tags=bbmap version=35.43
     - include: tasks/fastqc.yml tags=fastqc version=0.11.4
+    - include: tasks/splitstree.yml tags=splitstree version=4_14_2
 
     - include: tasks/macs2.yml tags=macs2 version=2.1.0.20140616
     - include: tasks/cutadapt.yml tags=cutadapt version=1.8

--- a/main.yml
+++ b/main.yml
@@ -35,7 +35,7 @@
     - include: tasks/vcftools.yml tags=vcftools version=0.1.12b
     - include: tasks/igvtools.yml tags=igvtools version=2.3.67
     - include: tasks/igv.yml tags=igv version=2.3.67
-    - include: tasks/gatk.yml tags=gatk version=3.3-0
+    - include: tasks/gatk.yml tags=gatk version=3.5
     - include: tasks/bowtie.yml tags=bowtie1 version=1.1.1
     - include: tasks/bowtie2.yml tags=bowtie2 version=2.2.5
     - include: tasks/trinity.yml tags=trinity version=2.0.6

--- a/main.yml
+++ b/main.yml
@@ -31,7 +31,7 @@
     - include: tasks/bcftools.yml tags=bcftools version=1.2
     - include: tasks/cufflinks.yml tags=cufflinks version=2.2.1
     - include: tasks/tophat.yml tags=tophat version=2.0.13
-    - include: tasks/ncbi-blast.yml tags=ncbi-blast version=2.2.31
+    - include: tasks/ncbi-blast.yml tags=ncbi-blast version=2.3.0
     - include: tasks/vcftools.yml tags=vcftools version=0.1.12b
     - include: tasks/igvtools.yml tags=igvtools version=2.3.52
     - include: tasks/igv.yml tags=igv version=2.3.52

--- a/main.yml
+++ b/main.yml
@@ -33,8 +33,8 @@
     - include: tasks/tophat.yml tags=tophat version=2.0.13
     - include: tasks/ncbi-blast.yml tags=ncbi-blast version=2.3.0
     - include: tasks/vcftools.yml tags=vcftools version=0.1.12b
-    - include: tasks/igvtools.yml tags=igvtools version=2.3.67
-    - include: tasks/igv.yml tags=igv version=2.3.67
+    - include: tasks/igvtools.yml tags=igvtools version=2.3.72
+    - include: tasks/igv.yml tags=igv version=2.3.72
     - include: tasks/gatk.yml tags=gatk version=3.5
     - include: tasks/bowtie.yml tags=bowtie1 version=1.1.1
     - include: tasks/bowtie2.yml tags=bowtie2 version=2.2.5

--- a/main.yml
+++ b/main.yml
@@ -34,7 +34,7 @@
     - include: tasks/ncbi-blast.yml tags=ncbi-blast version=2.3.0
     - include: tasks/vcftools.yml tags=vcftools version=0.1.12b
     - include: tasks/igvtools.yml tags=igvtools version=2.3.67
-    - include: tasks/igv.yml tags=igv version=2.3.52
+    - include: tasks/igv.yml tags=igv version=2.3.67
     - include: tasks/gatk.yml tags=gatk version=3.3-0
     - include: tasks/bowtie.yml tags=bowtie1 version=1.1.1
     - include: tasks/bowtie2.yml tags=bowtie2 version=2.2.5

--- a/scripts/brew2lmod.rb
+++ b/scripts/brew2lmod.rb
@@ -77,8 +77,15 @@ class FormulaInfo
       ]])
       
       local base = "#{base(ver)}"
+      local path = pathJoin(base, "bin")
       
-      prepend_path("PATH", pathJoin(base, "bin"))
+      prepend_path("PATH", path)
+
+      -- On load, list binaries
+      if (mode() == "load") then
+        local r = capture("ls " .. path)
+        LmodMessage("Loaded " .. myModuleName() .. " : " .. string.gsub(r,'\\n',' '))
+      end
     eos
   end
 

--- a/tarballs/README
+++ b/tarballs/README
@@ -1,11 +1,9 @@
 You need to manually download packages:
 
-http://www.broadinstitute.org/software/igv/download
-  IGV_2.3.42.zip
-  igvtools_2.3.42.zip
-
 https://www.broadinstitute.org/gatk/download/auth?package=GATK
   GenomeAnalysisTK-3.3-0.tar.bz2
 
-
+IGV and igvtools are automatically downloaded, however you should go here:
+  http://www.broadinstitute.org/software/igv/download
+and create and account, accept the license
 

--- a/tasks/SPAdes.yml
+++ b/tasks/SPAdes.yml
@@ -2,6 +2,11 @@
   get_url:
     url=http://spades.bioinf.spbau.ru/release{{version}}/SPAdes-{{version}}-Linux.tar.gz
     dest={{source_dir}}/SPAdes-{{version}}-Linux.tar.gz
+    timeout=30
+  register: get_url_result
+  until: "'OK' in get_url_result.msg or 'file already exists' in get_url_result.msg"
+  retries: 5
+  delay: 10
 
 - name: Uncompress SPAdes
   unarchive: 

--- a/tasks/STAR.yml
+++ b/tasks/STAR.yml
@@ -3,6 +3,7 @@
   git: repo=https://github.com/alexdobin/STAR
        dest={{source_dir}}/STAR-{{version}}
        version=STAR_{{version}}
+       update=yes
 
 - name: Install STAR
   shell: cd {{ source_dir }}/STAR-{{version}}/bin/Linux_x86_64_static; mkdir -p "{{ soft_dir }}/STAR-{{version}}/bin" && cp STAR STARlong "{{ soft_dir }}/STAR-{{version}}/bin"

--- a/tasks/abacas.yml
+++ b/tasks/abacas.yml
@@ -4,6 +4,11 @@
   get_url:
     url=http://internode.dl.sourceforge.net/project/abacas/abacas.{{version}}.pl
     dest="{{ soft_dir }}/ABACAS.{{version}}/bin"
+      timeout=30
+  register: get_url_result
+  until: "'OK' in get_url_result.msg or 'file already exists' in get_url_result.msg"
+  retries: 5
+  delay: 10
 
 - file: dest="{{ soft_dir }}/ABACAS.{{version}}/bin/abacas.{{version}}.pl" state=file mode=0755
 

--- a/tasks/artemis.yml
+++ b/tasks/artemis.yml
@@ -2,6 +2,11 @@
   get_url:
     url=ftp://ftp.sanger.ac.uk/pub/resources/software/artemis/artemis.tar.gz
     dest={{source_dir}}/artemis.tar.gz
+    timeout=30
+  register: get_url_result
+  until: "'OK' in get_url_result.msg or 'file already exists' in get_url_result.msg"
+  retries: 5
+  delay: 10
 
 - file: dest="{{soft_dir}}/artemis-{{version}}" state=directory mode=0755
 

--- a/tasks/artemis.yml
+++ b/tasks/artemis.yml
@@ -1,12 +1,16 @@
-- name: Download artemis
-  get_url:
-    url=ftp://ftp.sanger.ac.uk/pub/resources/software/artemis/artemis.tar.gz
-    dest={{source_dir}}/artemis.tar.gz
-    timeout=30
-  register: get_url_result
-  until: "'OK' in get_url_result.msg or 'file already exists' in get_url_result.msg"
-  retries: 5
-  delay: 10
+#- name: Download artemis
+#  get_url:
+#    url=ftp://ftp.sanger.ac.uk/pub/resources/software/artemis/artemis.tar.gz
+#    dest={{source_dir}}/artemis.tar.gz
+#    timeout=30
+#  register: get_url_result
+#  until: "'OK' in get_url_result.msg or 'file already exists' in get_url_result.msg"
+#  retries: 5
+#  delay: 10
+
+# get_url seems notoriously unreliable for ftp:// urls. So we use wget :/
+- name: Download artemis via wget
+  shell: wget -O {{source_dir}}/artemis.tar.gz --tries 5 --timeout 30 ftp://ftp.sanger.ac.uk/pub/resources/software/artemis/artemis.tar.gz
 
 - file: dest="{{soft_dir}}/artemis-{{version}}" state=directory mode=0755
 

--- a/tasks/bamstats.yml
+++ b/tasks/bamstats.yml
@@ -3,6 +3,11 @@
   get_url:
     url=http://sourceforge.net/projects/bamstats/files/BAMStats-{{version}}.zip/download
     dest={{source_dir}}/BAMStats-{{version}}.zip
+    timeout=30
+  register: get_url_result
+  until: "'OK' in get_url_result.msg or 'file already exists' in get_url_result.msg"
+  retries: 5
+  delay: 10
 
 - name: Uncompress BAMStats
   unarchive: 

--- a/tasks/bamutil.yml
+++ b/tasks/bamutil.yml
@@ -3,6 +3,11 @@
   get_url:
     url=https://github.com/statgen/bamUtil/archive/v{{version}}.tar.gz
     dest={{source_dir}}/bamUtil-{{version}}.tar.gz
+    timeout=30
+  register: get_url_result
+  until: "'OK' in get_url_result.msg or 'file already exists' in get_url_result.msg"
+  retries: 5
+  delay: 10
 
 - name: Uncompress bamUtil
   unarchive: 

--- a/tasks/bbmap.yml
+++ b/tasks/bbmap.yml
@@ -3,6 +3,11 @@
   get_url:
     url=http://sourceforge.net/projects/bbmap/files/BBMap_{{version}}.tar.gz/download
     dest={{source_dir}}/BBMap-{{version}}.tgz
+    timeout=30
+  register: get_url_result
+  until: "'OK' in get_url_result.msg or 'file already exists' in get_url_result.msg"
+  retries: 5
+  delay: 10
 
 - file: dest="{{ soft_dir }}/BBMap-{{version}}" state=directory mode=0755
 

--- a/tasks/bcftools.yml
+++ b/tasks/bcftools.yml
@@ -3,6 +3,11 @@
   get_url:
     url=https://github.com/samtools/bcftools/releases/download/{{version}}/bcftools-{{version}}.tar.bz2
     dest={{source_dir}}/bcftools-{{version}}.tar.bz2
+    timeout=30
+  register: get_url_result
+  until: "'OK' in get_url_result.msg or 'file already exists' in get_url_result.msg"
+  retries: 5
+  delay: 10
 
 - name: Uncompress bcftools
   unarchive: 

--- a/tasks/bedops.yml
+++ b/tasks/bedops.yml
@@ -2,6 +2,11 @@
   get_url:
     url=https://github.com/bedops/bedops/releases/download/v{{version}}/bedops_linux_x86_64-v{{version}}.tar.bz2
     dest={{source_dir}}/bedops_linux_x86_64-v{{version}}.tar.bz2
+    timeout=30
+  register: get_url_result
+  until: "'OK' in get_url_result.msg or 'file already exists' in get_url_result.msg"
+  retries: 5
+  delay: 10
 
 - file: dest="{{soft_dir}}/bedops-{{version}}" state=directory mode=0755
 

--- a/tasks/big-data-script.yml
+++ b/tasks/big-data-script.yml
@@ -2,6 +2,11 @@
   get_url:
     url=http://bioinformatics.erc.monash.edu/home/steve/host/bds_kirill_build_v{{version}}.tar.gz
     dest={{source_dir}}/bds_Linux-{{version}}.tgz
+    timeout=30
+  register: get_url_result
+  until: "'OK' in get_url_result.msg or 'file already exists' in get_url_result.msg"
+  retries: 5
+  delay: 10
 
 - file: dest="{{soft_dir}}/BigDataScript-{{version}}" state=directory mode=0755
 

--- a/tasks/blat.yml
+++ b/tasks/blat.yml
@@ -3,6 +3,11 @@
   get_url:
     url=https://users.soe.ucsc.edu/~kent/src/blatSrc{{version}}.zip
     dest={{source_dir}}/blatSrc{{version}}.zip
+    timeout=30
+  register: get_url_result
+  until: "'OK' in get_url_result.msg or 'file already exists' in get_url_result.msg"
+  retries: 5
+  delay: 10
 
 - file: dest="{{ source_dir }}/blatSrc{{version}}" state=directory mode=0755
 

--- a/tasks/bowtie.yml
+++ b/tasks/bowtie.yml
@@ -2,6 +2,11 @@
   get_url:
     url=http://sourceforge.net/projects/bowtie-bio/files/bowtie/{{version}}/bowtie-{{version}}-linux-x86_64.zip
     dest={{source_dir}}/bowtie-{{version}}-linux-x86_64.zip
+    timeout=30
+  register: get_url_result
+  until: "'OK' in get_url_result.msg or 'file already exists' in get_url_result.msg"
+  retries: 5
+  delay: 10
 
 - name: Uncompress Bowtie
   unarchive: 

--- a/tasks/bowtie2.yml
+++ b/tasks/bowtie2.yml
@@ -2,6 +2,11 @@
   get_url:
     url=http://sourceforge.net/projects/bowtie-bio/files/bowtie2/{{version}}/bowtie2-{{version}}-linux-x86_64.zip
     dest={{source_dir}}/bowtie2-{{version}}-linux-x86_64.zip
+    timeout=30
+  register: get_url_result
+  until: "'OK' in get_url_result.msg or 'file already exists' in get_url_result.msg"
+  retries: 5
+  delay: 10
 
 - name: Uncompress Bowtie2
   unarchive: 

--- a/tasks/bwa.yml
+++ b/tasks/bwa.yml
@@ -2,6 +2,11 @@
   get_url:
     url=http://sourceforge.net/projects/bio-bwa/files/bwa-0.7.12.tar.bz2
     dest={{source_dir}}/bwa-0.7.12.tar.bz2
+    timeout=30
+  register: get_url_result
+  until: "'OK' in get_url_result.msg or 'file already exists' in get_url_result.msg"
+  retries: 5
+  delay: 10
 
 - name: Uncompress BWA
   unarchive:

--- a/tasks/common-packages.yml
+++ b/tasks/common-packages.yml
@@ -42,3 +42,4 @@
     - texlive-latex-recommended
     - texlive-fonts-recommended
     - libzmq3-dev
+    - libncurses5-dev

--- a/tasks/common-packages.yml
+++ b/tasks/common-packages.yml
@@ -11,6 +11,7 @@
     - liblua5.2-dev
     - lua-filesystem
     - lua-posix
+    - build-essential
     - gcc
     - git
     - tcl

--- a/tasks/cran-r.yml
+++ b/tasks/cran-r.yml
@@ -1,5 +1,7 @@
+- name: Adding key for CRAN apt repository
+  apt_key: keyserver=keyserver.ubuntu.com id=E084DAB9 state=present
 
-- name: Adding apt repo
+- name: Adding apt repo for CRAN
   apt_repository: repo='deb http://cran.ms.unimelb.edu.au/bin/linux/ubuntu trusty/' state=present
 
 

--- a/tasks/cufflinks.yml
+++ b/tasks/cufflinks.yml
@@ -2,6 +2,11 @@
   get_url:
     url=http://cole-trapnell-lab.github.io/cufflinks/assets/downloads/cufflinks-{{version}}.Linux_x86_64.tar.gz
     dest={{source_dir}}/cufflinks-{{version}}.Linux_x86_64.tar.gz
+    timeout=30
+  register: get_url_result
+  until: "'OK' in get_url_result.msg or 'file already exists' in get_url_result.msg"
+  retries: 5
+  delay: 10
 
 - name: Uncompress Cufflinks
   unarchive: 

--- a/tasks/fastqc.yml
+++ b/tasks/fastqc.yml
@@ -2,6 +2,11 @@
   get_url:
     url=http://www.bioinformatics.babraham.ac.uk/projects/fastqc/fastqc_v{{version}}.zip
     dest={{ source_dir }}/fastqc_v{{ version }}.zip
+    timeout=30
+  register: get_url_result
+  until: "'OK' in get_url_result.msg or 'file already exists' in get_url_result.msg"
+  retries: 5
+  delay: 10
 
 - name: Uncompress FastQC
   unarchive:

--- a/tasks/gatk.yml
+++ b/tasks/gatk.yml
@@ -1,32 +1,42 @@
 
+- stat: path=tarballs/GenomeAnalysisTK-{{version}}.tar.bz2
+  register: gatktarball
+
+- debug: msg="Skipping installation of GATK - tarballs/GenomeAnalysisTK-{{version}}.tar.bz2 not found."
+  when: not gatktarball.stat.exists
+
 # Create a directory for extraction
 - file: dest="{{ soft_dir }}/GenomeAnalysisTK-{{version}}" state=directory mode=0755
+  when: gatktarball.stat.exists
 
 - name: Uncompress GATK
-  unarchive: 
+  unarchive:
     src: tarballs/GenomeAnalysisTK-{{version}}.tar.bz2
     dest: "{{ soft_dir }}/GenomeAnalysisTK-{{version}}"
     copy: yes
     creates: "{{ soft_dir }}/GenomeAnalysisTK-{{version}}/GenomeAnalysisTK.jar"
+  when: gatktarball.stat.exists
 
 - name: GATK wrapper script
   template:
     src: templates/java-wrapper.sh.j2
     dest: "{{ soft_dir }}/GenomeAnalysisTK-{{version}}/gatk"
-    owner: root 
+    owner: root
     mode: 0755
   with_items:
     - { jar: '{{ soft_dir }}/GenomeAnalysisTK-{{version}}/GenomeAnalysisTK.jar' }
+  when: gatktarball.stat.exists
 
 - file: dest="{{modules_dir}}/bio/gatk" state=directory mode=0755
+  when: gatktarball.stat.exists
 
 - name: GATK module definition
-  template: 
-    src: templates/sw-module.lua.j2 
+  template:
+    src: templates/sw-module.lua.j2
     dest: "{{ modules_dir }}/bio/gatk/{{version}}.lua"
-    owner: root 
+    owner: root
     mode: 0644
   with_items:
     - { help_text: 'The Genome Analysis Toolkit or GATK', dir: 'GenomeAnalysisTK-{{version}}', skip_bin: true }
-
+  when: gatktarball.stat.exists
 

--- a/tasks/hisat.yml
+++ b/tasks/hisat.yml
@@ -2,6 +2,11 @@
   get_url:
     url=http://www.ccb.jhu.edu/software/hisat/downloads/hisat-{{version}}-Linux_x86_64.zip
     dest={{source_dir}}/hisat-{{version}}-Linux_x86_64.zip
+    timeout=30
+  register: get_url_result
+  until: "'OK' in get_url_result.msg or 'file already exists' in get_url_result.msg"
+  retries: 5
+  delay: 10
 
 - name: Uncompress hisat
   unarchive: 

--- a/tasks/hmmer.yml
+++ b/tasks/hmmer.yml
@@ -1,6 +1,6 @@
 - name: Download hmmer
   get_url:
-    url=http://selab.janelia.org/software/hmmer3/{{version}}/hmmer-{{version}}-linux-intel-x86_64.tar.gz
+    url=http://eddylab.org/software/hmmer3/{{version}}/hmmer-{{version}}-linux-intel-x86_64.tar.gz
     dest={{source_dir}}/hmmer-{{version}}-linux-intel-x86_64.tar.gz
 
 - name: Uncompress hmmer

--- a/tasks/hmmer.yml
+++ b/tasks/hmmer.yml
@@ -2,6 +2,11 @@
   get_url:
     url=http://eddylab.org/software/hmmer3/{{version}}/hmmer-{{version}}-linux-intel-x86_64.tar.gz
     dest={{source_dir}}/hmmer-{{version}}-linux-intel-x86_64.tar.gz
+    timeout=30
+  register: get_url_result
+  until: "'OK' in get_url_result.msg or 'file already exists' in get_url_result.msg"
+  retries: 5
+  delay: 10
 
 - name: Uncompress hmmer
   unarchive: 

--- a/tasks/homer.yml
+++ b/tasks/homer.yml
@@ -5,6 +5,11 @@
   get_url:
     url=http://homer.salk.edu/homer/configureHomer.pl
     dest={{soft_dir}}/homer/configureHomer.pl
+    timeout=30
+  register: get_url_result
+  until: "'OK' in get_url_result.msg or 'file already exists' in get_url_result.msg"
+  retries: 5
+  delay: 10
 
 - name: Build Homer
   shell: cd {{ soft_dir }}/homer; perl configureHomer.pl -install

--- a/tasks/htslib.yml
+++ b/tasks/htslib.yml
@@ -3,6 +3,11 @@
   get_url:
     url=https://github.com/samtools/htslib/archive/{{version}}.tar.gz
     dest={{source_dir}}/htslib-{{version}}.tar.gz
+    timeout=30
+  register: get_url_result
+  until: "'OK' in get_url_result.msg or 'file already exists' in get_url_result.msg"
+  retries: 5
+  delay: 10
 
 - name: Uncompress htslib
   unarchive: 

--- a/tasks/igv.yml
+++ b/tasks/igv.yml
@@ -1,4 +1,7 @@
 
+- stat: path=tarballs/IGV_{{version}}.zip
+  register: igvzip
+
 # Check if it has been uncompressed.  The "creates" in the next section should do this, but it
 # seems to copy up the tarball anyway
 - stat: path={{ soft_dir}}/IGV_{{version}}/igv.sh
@@ -10,7 +13,10 @@
     dest={{ soft_dir }}
     copy=yes
     creates={{ soft_dir}}/IGV_{{version}}/igv.sh
-  when: not igv.stat.exists
+  when: not igv.stat.exists and igvzip.stat.exists
+
+- debug: msg="Didn't find tarballs/IGV_{{version}}.zip - not installing IGV"
+  when: not igvzip.stat.exists
 
 - file: dest="{{modules_dir}}/bio/igv" state=directory mode=0755
 

--- a/tasks/igv.yml
+++ b/tasks/igv.yml
@@ -3,6 +3,11 @@
   get_url:
     url=http://data.broadinstitute.org/igv/projects/downloads/IGV_{{version}}.zip
     dest=tarballs/IGV_{{version}}.zip
+    timeout=30
+  register: get_url_result
+  until: "'OK' in get_url_result.msg or 'file already exists' in get_url_result.msg"
+  retries: 5
+  delay: 10
 
 - stat: path=tarballs/IGV_{{version}}.zip
   register: igvzip

--- a/tasks/igv.yml
+++ b/tasks/igv.yml
@@ -1,4 +1,9 @@
 
+- name: Download IGV - you should register here https://www.broadinstitute.org/software/igv/?q=registration and agree with the license terms (LGPL, http://www.opensource.org/licenses/lgpl-2.1.php)
+  get_url:
+    url=http://data.broadinstitute.org/igv/projects/downloads/IGV_{{version}}.zip
+    dest=tarballs/IGV_{{version}}.zip
+
 - stat: path=tarballs/IGV_{{version}}.zip
   register: igvzip
 

--- a/tasks/igvtools.yml
+++ b/tasks/igvtools.yml
@@ -2,6 +2,9 @@
 # Ensure the unarchive directory exists (the zip file has no version info)
 - file: dest="{{ soft_dir }}/IGVTools-{{version}}" state=directory mode=0755
 
+- stat: path=tarballs/igvtools_{{version}}.zip
+  register: igvtoolszip
+
 # Check if it has been uncompressed.  The "creates" in the next section should do this, but it
 # seems to copy up the tarball anyway
 - stat: path={{ soft_dir }}/IGVTools-{{version}}/IGVTools/igvtools
@@ -13,7 +16,10 @@
     dest={{ soft_dir }}/IGVTools-{{version}}
     copy=yes
     creates={{ soft_dir }}/IGVTools-{{version}}/IGVTools/igvtools
-  when: not igvtools.stat.exists
+  when: not igvtools.stat.exists and igvtoolszip.stat.exists
+
+- debug: msg="Didn't find tarballs/igvtools_{{version}}.zip - not installing igvtools"
+  when: not igvtoolszip.stat.exists
 
 - file: dest="{{modules_dir}}/bio/igvtools" state=directory mode=0755
 

--- a/tasks/igvtools.yml
+++ b/tasks/igvtools.yml
@@ -3,6 +3,11 @@
   get_url:
     url=http://data.broadinstitute.org/igv/projects/downloads/igvtools_{{version}}.zip
     dest=tarballs/igvtools_{{version}}.zip
+    timeout=30
+  register: get_url_result
+  until: "'OK' in get_url_result.msg or 'file already exists' in get_url_result.msg"
+  retries: 5
+  delay: 10
 
 # Ensure the unarchive directory exists (the zip file has no version info)
 - file: dest="{{ soft_dir }}/IGVTools-{{version}}" state=directory mode=0755

--- a/tasks/igvtools.yml
+++ b/tasks/igvtools.yml
@@ -1,4 +1,9 @@
 
+- name: Download igvtools - you should register here https://www.broadinstitute.org/software/igv/?q=registration and agree with the license terms (LGPL, http://www.opensource.org/licenses/lgpl-2.1.php)
+  get_url:
+    url=http://data.broadinstitute.org/igv/projects/downloads/igvtools_{{version}}.zip
+    dest=tarballs/igvtools_{{version}}.zip
+
 # Ensure the unarchive directory exists (the zip file has no version info)
 - file: dest="{{ soft_dir }}/IGVTools-{{version}}" state=directory mode=0755
 

--- a/tasks/lmod.yml
+++ b/tasks/lmod.yml
@@ -13,6 +13,11 @@
     url=http://downloads.sourceforge.net/project/lmod/Lmod-{{ lmod_version }}.tar.bz2
     dest={{source_dir}}/Lmod-{{ lmod_version }}.tar.bz2
     mode=0444
+    timeout=30
+  register: get_url_result
+  until: "'OK' in get_url_result.msg or 'file already exists' in get_url_result.msg"
+  retries: 5
+  delay: 10
 
 - name: Uncompress LMOD
   unarchive:

--- a/tasks/misc_utils.yml
+++ b/tasks/misc_utils.yml
@@ -14,6 +14,7 @@
 - include: brew_package.yml brew_name='homebrew/science/mrbayes' lmod_name='mrbayes'
 - include: brew_package.yml brew_name='homebrew/science/trimmomatic' lmod_name='trimmomatic'
 - include: brew_package.yml brew_name='homebrew/science/snpeff' lmod_name='snpeff'
+- include: brew_package.yml brew_name='homebrew/science/sratoolkit' lmod_name='sratoolkit'
 
 #- include: brew_package.yml brew_name='homebrew/science/plink2' lmod_name='plink2'
 #- include: brew_package.yml brew_name='homebrew/science/repeatmasker' lmod_name='repeatmasker'

--- a/tasks/misc_utils.yml
+++ b/tasks/misc_utils.yml
@@ -15,6 +15,7 @@
 - include: brew_package.yml brew_name='homebrew/science/trimmomatic' lmod_name='trimmomatic'
 - include: brew_package.yml brew_name='homebrew/science/snpeff' lmod_name='snpeff'
 - include: brew_package.yml brew_name='homebrew/science/sratoolkit' lmod_name='sratoolkit'
+- include: brew_package.yml brew_name='homebrew/science/seqtk' lmod_name='seqtk'
 
 #- include: brew_package.yml brew_name='homebrew/science/plink2' lmod_name='plink2'
 #- include: brew_package.yml brew_name='homebrew/science/repeatmasker' lmod_name='repeatmasker'

--- a/tasks/misc_utils.yml
+++ b/tasks/misc_utils.yml
@@ -16,6 +16,7 @@
 - include: brew_package.yml brew_name='homebrew/science/snpeff' lmod_name='snpeff'
 - include: brew_package.yml brew_name='homebrew/science/sratoolkit' lmod_name='sratoolkit'
 - include: brew_package.yml brew_name='homebrew/science/seqtk' lmod_name='seqtk'
+- include: brew_package.yml brew_name='homebrew/science/fasta' lmod_name='fasta'
 
 #- include: brew_package.yml brew_name='homebrew/science/plink2' lmod_name='plink2'
 #- include: brew_package.yml brew_name='homebrew/science/repeatmasker' lmod_name='repeatmasker'

--- a/tasks/mummer.yml
+++ b/tasks/mummer.yml
@@ -14,6 +14,11 @@
   get_url:
     url=http://internode.dl.sourceforge.net/project/mummer/mummer/{{version}}/MUMmer{{version}}.tar.gz
     dest={{source_dir}}/MUMmer{{version}}.tar.gz
+    timeout=30
+  register: get_url_result
+  until: "'OK' in get_url_result.msg or 'file already exists' in get_url_result.msg"
+  retries: 5
+  delay: 10
 
 - name: Uncompress MUMmer
   unarchive: 

--- a/tasks/ncbi-blast.yml
+++ b/tasks/ncbi-blast.yml
@@ -2,6 +2,11 @@
   get_url:
     url=ftp://ftp.ncbi.nlm.nih.gov/blast/executables/blast+/LATEST/ncbi-blast-{{version}}+-x64-linux.tar.gz
     dest={{source_dir}}/ncbi-blast-{{version}}+-x64-linux.tar.gz
+    timeout=30
+  register: get_url_result
+  until: "'OK' in get_url_result.msg or 'file already exists' in get_url_result.msg"
+  retries: 5
+  delay: 10
 
 - name: Uncompress NCBI Blast
   unarchive: 

--- a/tasks/ncbi-blast.yml
+++ b/tasks/ncbi-blast.yml
@@ -1,6 +1,6 @@
 - name: Download NCBI Blast
   get_url:
-    url=ftp://ftp.ncbi.nlm.nih.gov/blast/executables/blast+/LATEST/ncbi-blast-{{version}}+-x64-linux.tar.gz
+    url=http://ftp.ncbi.nlm.nih.gov/blast/executables/blast+/LATEST/ncbi-blast-{{version}}+-x64-linux.tar.gz
     dest={{source_dir}}/ncbi-blast-{{version}}+-x64-linux.tar.gz
     timeout=30
   register: get_url_result

--- a/tasks/picard.yml
+++ b/tasks/picard.yml
@@ -3,6 +3,11 @@
   get_url:
     url=https://github.com/broadinstitute/picard/releases/download/{{version}}/picard-tools-{{version}}.zip
     dest={{source_dir}}/picard-tools-{{version}}.zip
+    timeout=30
+  register: get_url_result
+  until: "'OK' in get_url_result.msg or 'file already exists' in get_url_result.msg"
+  retries: 5
+  delay: 10
 
 - name: Uncompress Picard
   unarchive: 

--- a/tasks/prokka.yml
+++ b/tasks/prokka.yml
@@ -6,6 +6,12 @@
     - XML::Simple
     - Bio::Perl
 
+# from https://github.com/Homebrew/homebrew-science/issues/3508 to fix blast install problem
+- name: Install prokka dep blast from custom source
+  shell: "{{brew_dir}}/bin/brew pull https://github.com/Homebrew/homebrew-science/pull/3537; {{brew_dir}}/bin/brew install --build-from-source -dv blast"
+  sudo: yes
+  sudo_user: sw-installer
+
 - include: brew_package.yml brew_name='homebrew/science/prokka' lmod_name='prokka'
 
 - name: Setup prokka dbs

--- a/tasks/prokka.yml
+++ b/tasks/prokka.yml
@@ -1,8 +1,10 @@
 
 - name: Install prokka dependencies
-  cpanm: name=Bio::Perl
-
-- cpanm: name=XML::Simple
+  cpanm: name={{item}}
+  with_items:
+    - LWP::UserAgent
+    - XML::Simple
+    - Bio::Perl
 
 - include: brew_package.yml brew_name='homebrew/science/prokka' lmod_name='prokka'
 

--- a/tasks/qiime.yml
+++ b/tasks/qiime.yml
@@ -1,4 +1,11 @@
 
+- name: Install qiime dependencies
+  apt: pkg={{item}} state=present
+  with_items:
+    - libblas-dev
+    - liblapack-dev
+    - gfortran
+
 - name: qiime
   pip: name=qiime version={{version}} virtualenv={{soft_dir}}/qiime-{{version}} virtualenv_site_packages=yes
 
@@ -15,5 +22,3 @@
     mode: 0644
   with_items:
     - { help_text: 'QIIME is an open-source bioinformatics pipeline for performing microbiome analysis from raw DNA sequencing data', dir: 'qiime-{{version}}', append: true }
-
-

--- a/tasks/rna-seqc.yml
+++ b/tasks/rna-seqc.yml
@@ -5,6 +5,11 @@
   get_url:
     url=http://www.broadinstitute.org/cancer/cga/tools/rnaseqc/RNA-SeQC_v{{version}}.jar
     dest={{ soft_dir }}/RNA-SeQC_v{{version}}/RNA-SeQC_v{{version}}.jar
+    timeout=30
+  register: get_url_result
+  until: "'OK' in get_url_result.msg or 'file already exists' in get_url_result.msg"
+  retries: 5
+  delay: 10
 
 - name: RNA-SeQC wrapper script
   template:

--- a/tasks/rseqc.yml
+++ b/tasks/rseqc.yml
@@ -4,6 +4,11 @@
   get_url:
     url=http://sourceforge.net/projects/rseqc/files/RSeQC-{{version}}.tar.gz/download
     dest={{source_dir}}/RSeQC-{{version}}.tar.gz
+    timeout=30
+  register: get_url_result
+  until: "'OK' in get_url_result.msg or 'file already exists' in get_url_result.msg"
+  retries: 5
+  delay: 10
 
 - name: Uncompress RSeQC
   unarchive:

--- a/tasks/rstudio-server-daily.yml
+++ b/tasks/rstudio-server-daily.yml
@@ -8,6 +8,11 @@
   get_url:
     url=https://s3.amazonaws.com/rstudio-dailybuilds/rstudio-server-{{version}}.deb
     dest={{source_dir}}/rstudio-server-{{version}}.deb
+    timeout=30
+  register: get_url_result
+  until: "'OK' in get_url_result.msg or 'file already exists' in get_url_result.msg"
+  retries: 5
+  delay: 10
 
 - name: Install Rstudio server daily
   shell: gdebi -n {{source_dir}}/rstudio-server-{{version}}.deb

--- a/tasks/rstudio-server.yml
+++ b/tasks/rstudio-server.yml
@@ -9,6 +9,11 @@
   get_url:
     url=http://download2.rstudio.org/rstudio-server-{{version}}.deb
     dest={{source_dir}}/rstudio-server-{{version}}.deb
+    timeout=30
+  register: get_url_result
+  until: "'OK' in get_url_result.msg or 'file already exists' in get_url_result.msg"
+  retries: 5
+  delay: 10
 
 - name: Install Rstudio server
   shell: gdebi -n {{source_dir}}/rstudio-server-{{version}}.deb

--- a/tasks/samtools.yml
+++ b/tasks/samtools.yml
@@ -3,6 +3,11 @@
   get_url:
     url=https://github.com/samtools/samtools/archive/{{version}}.tar.gz
     dest={{source_dir}}/samtools-{{version}}.tar.gz
+    timeout=30
+  register: get_url_result
+  until: "'OK' in get_url_result.msg or 'file already exists' in get_url_result.msg"
+  retries: 5
+  delay: 10
 
 - name: Uncompress samtools
   unarchive: 

--- a/tasks/splitstree.yml
+++ b/tasks/splitstree.yml
@@ -5,7 +5,7 @@
     dest={{source_dir}}/splitstree4_unix_{{version}}.sh
 
 - name: Install SplitsTee
-  shell: cd {{source_dir}}; echo "o\n1\n{{soft_dir}}/SplitsTree-{{version}}\n\nn\n" | sh splitstree4_unix_{{version}}.sh
+  shell: cd {{source_dir}}; echo "o\n\n1\n{{soft_dir}}/SplitsTree-{{version}}\n1\nn\n5\n65535\n" | sh splitstree4_unix_{{version}}.sh
   args:
     creates: "{{soft_dir}}/SplitsTree-{{version}}/SplitsTree"
 

--- a/tasks/splitstree.yml
+++ b/tasks/splitstree.yml
@@ -3,6 +3,11 @@
   get_url:
     url=http://ab.inf.uni-tuebingen.de/data/software/splitstree4/download/splitstree4_unix_{{version}}.sh
     dest={{source_dir}}/splitstree4_unix_{{version}}.sh
+    timeout=30
+  register: get_url_result
+  until: "'OK' in get_url_result.msg or 'file already exists' in get_url_result.msg"
+  retries: 5
+  delay: 10
 
 - name: Install SplitsTee
   shell: cd {{source_dir}}; echo "o\n\n1\n{{soft_dir}}/SplitsTree-{{version}}\n1\nn\n5\n65535\n" | sh splitstree4_unix_{{version}}.sh

--- a/tasks/splitstree.yml
+++ b/tasks/splitstree.yml
@@ -1,0 +1,23 @@
+
+- name: Download SplitsTree
+  get_url:
+    url=http://ab.inf.uni-tuebingen.de/data/software/splitstree4/download/splitstree4_unix_{{version}}.sh
+    dest={{source_dir}}/splitstree4_unix_{{version}}.sh
+
+- name: Install SplitsTee
+  shell: cd {{source_dir}}; echo "o\n1\n{{soft_dir}}/SplitsTree-{{version}}\n\nn\n" | sh splitstree4_unix_{{version}}.sh
+  args:
+    creates: "{{soft_dir}}/SplitsTree-{{version}}/SplitsTree"
+
+- file: dest="{{modules_dir}}/bio/splitstree" state=directory mode=0755
+
+- name: SplitsTree module definition
+  template: 
+    src: templates/sw-module.lua.j2 
+    dest: "{{ modules_dir }}/bio/splitstree/{{version}}.lua"
+    owner: root 
+    mode: 0644
+  with_items:
+    - { help_text: 'This module loads the SplitsTree tool for building and visualising trees', dir: 'SplitsTree-{{version}}', skip_bin: True }
+
+

--- a/tasks/tophat.yml
+++ b/tasks/tophat.yml
@@ -2,6 +2,11 @@
   get_url:
     url=http://ccb.jhu.edu/software/tophat/downloads/tophat-{{version}}.Linux_x86_64.tar.gz
     dest={{source_dir}}/tophat-{{version}}.Linux_x86_64.tar.gz
+    timeout=30
+  register: get_url_result
+  until: "'OK' in get_url_result.msg or 'file already exists' in get_url_result.msg"
+  retries: 5
+  delay: 10
 
 - name: Uncompress TopHat
   unarchive: 

--- a/tasks/trimmomatic.yml
+++ b/tasks/trimmomatic.yml
@@ -3,6 +3,11 @@
   get_url:
     url=http://www.usadellab.org/cms/uploads/supplementary/Trimmomatic/Trimmomatic-{{version}}.zip
     dest={{source_dir}}/Trimmomatic-{{version}}.zip
+    timeout=30
+  register: get_url_result
+  until: "'OK' in get_url_result.msg or 'file already exists' in get_url_result.msg"
+  retries: 5
+  delay: 10
 
 - name: Uncompress Trimmomatic
   unarchive: 

--- a/tasks/trinity.yml
+++ b/tasks/trinity.yml
@@ -3,6 +3,11 @@
   get_url:
     url=https://github.com/trinityrnaseq/trinityrnaseq/archive/v{{version}}.tar.gz
     dest={{source_dir}}/trinity-{{version}}.tar.gz
+    timeout=30
+  register: get_url_result
+  until: "'OK' in get_url_result.msg or 'file already exists' in get_url_result.msg"
+  retries: 5
+  delay: 10
 
 - name: Uncompress Trinity
   unarchive: 

--- a/tasks/ucsc-tools.yml
+++ b/tasks/ucsc-tools.yml
@@ -9,6 +9,11 @@
   get_url:
     url=http://hgdownload.cse.ucsc.edu/admin/exe/userApps.v{{version}}.src.tgz
     dest={{source_dir}}/ucsc-userApps.v{{version}}.src.tgz
+    timeout=30
+  register: get_url_result
+  until: "'OK' in get_url_result.msg or 'file already exists' in get_url_result.msg"
+  retries: 5
+  delay: 10
 
 - file: dest="{{ source_dir }}/UCSC-tools.v{{version}}" state=directory mode=0755
 

--- a/tasks/vcftools.yml
+++ b/tasks/vcftools.yml
@@ -3,6 +3,11 @@
   get_url:
     url=http://downloads.sourceforge.net/project/vcftools/vcftools_{{version}}.tar.gz
     dest={{source_dir}}/vcftools_{{version}}.tar.gz
+    timeout=30
+  register: get_url_result
+  until: "'OK' in get_url_result.msg or 'file already exists' in get_url_result.msg"
+  retries: 5
+  delay: 10
 
 - name: Uncompress vcftools
   unarchive: 

--- a/tasks/velvet.yml
+++ b/tasks/velvet.yml
@@ -3,6 +3,11 @@
   get_url:
     url=https://www.ebi.ac.uk/~zerbino/velvet/velvet_{{version}}.tgz
     dest={{source_dir}}/velvet_{{version}}.tgz
+    timeout=30
+  register: get_url_result
+  until: "'OK' in get_url_result.msg or 'file already exists' in get_url_result.msg"
+  retries: 5
+  delay: 10
 
 - name: Uncompress Velvet
   unarchive: 

--- a/templates/sw-module.lua.j2
+++ b/templates/sw-module.lua.j2
@@ -45,7 +45,7 @@ LmodMessage("{{ item.msg }}")
 {% endif %}
 
 -- On load, list binaries
-if (mode() == "load") then
+if (mode() == "load" and os.getenv("LMOD_LOG")) then
   local r = capture("ls " .. path)
   LmodMessage("Loaded " .. myModuleName() .. " : " .. string.gsub(r,'\n',' '))
 end

--- a/templates/sw-module.lua.j2
+++ b/templates/sw-module.lua.j2
@@ -44,3 +44,9 @@ load({{ item.depend }})
 LmodMessage("{{ item.msg }}")
 {% endif %}
 
+-- On load, list binaries
+if (mode() == "load") then
+  local r = capture("ls " .. path)
+  LmodMessage("Loaded " .. myModuleName() .. " : " .. string.gsub(r,'\n',' '))
+end
+


### PR DESCRIPTION
In the process of wrapping up bio-ansible as a 'one-click' Murano app, I've been trying to make the process more resilient. Ansible doesn't seem to retry get_url operations by default, which means occasional dropped / stalled connections cause the entire playbook to fail. This patch adds retries and a longer timeout to all get_url operations.

I've also found that get_url fails on ftp:// URL at fairly high frequency (but not always). Not sure if this is something to do with not supporting PASSIVE mode and host firewall rules, however the workaround is to use "shell: wget ..." for ftp:// URLs instead.
