### PR TITLE
Move default variables to role/default/main.yml

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,8 @@ If running against remote host(s):
 2b. Set up your [ssh-keys](https://www.digitalocean.com/community/tutorials/how-to-set-up-ssh-keys--2)
 2c. Edit `hosts` file to include the remote host IP addresses into the appropriate group
 3. Edit `group/all` file to include your username as `main_guy` variable
-4. Download any tar archives for non-FOSS software into `tarballs/` - 
+4. Download any tar archives for non-FOSS software into `tarballs/` (or the
+   path set in the `tarballs_path` variable) - 
 see the section on [manually downloading tarballs](#manually-downloading-tarballs) below.
 
 #### Running the playbooks
@@ -114,8 +115,10 @@ diagnose failures_
 ### Manually downloading tarballs
 
 Because of the licenses some installation files need to be manually downloaded 
-into `tarballs` directory. The `playbook.yml` will skip installation of those 
-packages if it doesn't find the archive files in that directory.
+into a 'tarballs' directory. By default this is `tarballs` in the playbook base 
+path - this location can be set using the `tarballs_path` variable if required. 
+The `playbook.yml` will skip installation of those packages if it doesn't find 
+the archive files in that directory.
 
 ### Manual scripts
 

--- a/cephfs.yml
+++ b/cephfs.yml
@@ -1,0 +1,9 @@
+- name: Install and mount CephFS
+  hosts: common
+  remote_user: "{{ sudo_guy }}"
+  become: true
+  roles:
+    # make container for all other installation
+    # - common
+    # lmod as a module
+    - cephfs

--- a/group_vars/all
+++ b/group_vars/all
@@ -10,6 +10,7 @@ main_guy_pubkey: ""
 # Different directories variables
 #---------------------------------
 private_vars_path: "{{ playbook_dir }}/private"
+tarballs_path: "{{ playbook_dir }}/tarballs"
 local_home: "{{ ansible_env.HOME }}"
 bioansible_basepath: "{{ local_home }}/bioansible"
 source_dir: "{{ bioansible_basepath }}/software/source"
@@ -29,7 +30,8 @@ threads: 4
 del_src: "" # empty string means true and "not" negates that
 
 r_base_mirror: "https://cran.csiro.au"
-# training data, mainly for biotraining server
-r_intro_version: gh-pages
-r_more_version: gh-pages
-r_de_analysis_version: gh-pages
+
+# java version
+jdk_major: 8
+jdk_minor: 144
+java_oracle_version: "{{ jdk_major }}u{{ jdk_minor }}"

--- a/group_vars/bio
+++ b/group_vars/bio
@@ -24,7 +24,7 @@ subread_version: 1.5.2
 picard_version: 2.9.0
 gatk_version: 3.7
 fastqc_version: 0.11.5
-freebayes_version: 1.1.0
+freebayes_version: 1.1.0.46
 vcflib_version: master
 sratoolkit_version: 2.8.0
 rnasik_version: 1.4.7
@@ -46,7 +46,7 @@ cdhit_version: 4.6.7
 mothur_version: 1.39.5
 bcl2fastq2_version: 2.19.1
 emboss_version: 6.6.0
-#infernal_version: 1.1.2
+infernal_version: 1.1.2
 # python virtualenv
 mimodd_version: 0.1.7.3
 multiqc_version: 1.0

--- a/group_vars/bio
+++ b/group_vars/bio
@@ -53,6 +53,7 @@ multiqc_version: 1.0
 cutadapt_version: 1.12
 macs2_version: 2.1.1.20160309
 qiime_version: 1.9.1
+gatk4_version: 4.0b2
 
 # bds version
 bds_version: 0.99999g

--- a/group_vars/bio
+++ b/group_vars/bio
@@ -3,80 +3,15 @@
 # Tool versions
 #---------------------
 #
-# java version
-jdk_major: 8
-jdk_minor: 144
-java_oracle_version: "{{ jdk_major }}u{{ jdk_minor }}"
-# lmod version
-lmod_version: 7.3.9
-# R 
-r_base_version: 3.4.0
-#r_lib_path: "lib64/R/library"
-r_lib_path: "lib/R/library"
-# bio_tools versions
-star_version: 2.5.2b
-bwa_version: v0.7.15
-bowtie2_version: v2.3.2
-htslib_version: 1.4.1
-samtools_version: 1.4.1
-bcftools_version: 1.4.1
-subread_version: 1.5.2
-picard_version: 2.9.0
-gatk_version: 3.7
-fastqc_version: 0.11.5
-freebayes_version: 1.1.0
-vcflib_version: master
-sratoolkit_version: 2.8.0
-rnasik_version: 1.4.7
-qualimap_version: v2.2.1
-seqtk_version: v1.2
-igv_version: 2.3.94
-bedtools2_version: 2.25.0
-blast_version: 2.6.0
-smalt_version: 0.7.6
-snpeff_version: "4_3i"
-spades_version: 3.10.0
-vsearch_version: 2.4.0
-raxml_version: 8.2.9
-raxml_makefile: Makefile.AVX.PTHREADS.gcc
-cellranger_version: 1.3.1
-vcftools_version: 0.1.14
-muscle_version: 3.8.31
-cdhit_version: 4.6.7
-mothur_version: 1.39.5
-bcl2fastq2_version: 2.19.1
-emboss_version: 6.6.0
-#infernal_version: 1.1.2
-# python virtualenv
-mimodd_version: 0.1.7.3
-multiqc_version: 1.0
-cutadapt_version: 1.12
-macs2_version: 2.1.1.20160309
-qiime_version: 1.9.1
 
-# bds version
-bds_version: 0.99999g
-bds_config:
-  tmpDir: /tmp
-
-# perl
-biotradis_version: 1.3.3
-bioperl_version: 1.007001
-# extra packages
-stack_version: 1.2.0
-nodejs_version: v6.9.1
-maven_version: 3.3.9
-tmux_version: 2.4
-hifive_version: 1.4.0
-ant_version: 1.10.1
-go_version: 1.8.3
-
-python3_executable: "python3"
-python3_virtualenv: "virtualenv"
-# Should match Python version used above, so site-packages 
-# in the virtualenv(s) can be found
-mimodd_python_version: "python3.5"
-
-# Compilation option: NO_TBB (Thread Building Blocks vs pthreads)
-# Valid values: 1 or 0
-bowtie2_notbb: 0
+# Version variables have moved into role-specific defaults, but can still be
+# overridden for the 'bio' group of hosts here:
+#
+# See:
+# bio_tools/defaults/main.yml
+# java/defaults/main.yml
+# R/defaults/main.yml
+# bds/defaults/main.yml
+# lmod/defaults/main.yml
+# lmod_etc/defaults/main.yml
+# extra/defaults/main.yml

--- a/group_vars/bio
+++ b/group_vars/bio
@@ -1,83 +1,11 @@
----
-#---------------------
-# Tool versions
-#---------------------
+# Version variables have moved into role-specific defaults, but can still be
+# overridden for the 'bio' group of hosts here:
 #
-# java version
-jdk_major: 8
-jdk_minor: 144
-java_oracle_version: "{{ jdk_major }}u{{ jdk_minor }}"
-# lmod version
-lmod_version: 7.3.9
-# R 
-r_base_version: 3.4.0
-#r_lib_path: "lib64/R/library"
-r_lib_path: "lib/R/library"
-# bio_tools versions
-star_version: 2.5.2b
-bwa_version: v0.7.15
-bowtie2_version: v2.3.2
-htslib_version: 1.4.1
-samtools_version: 1.4.1
-bcftools_version: 1.4.1
-subread_version: 1.5.2
-picard_version: 2.9.0
-gatk_version: 3.7
-fastqc_version: 0.11.5
-freebayes_version: 1.1.0.46
-vcflib_version: master
-sratoolkit_version: 2.8.0
-rnasik_version: 1.4.7
-qualimap_version: v2.2.1
-seqtk_version: v1.2
-igv_version: 2.3.94
-bedtools2_version: 2.25.0
-blast_version: 2.6.0
-smalt_version: 0.7.6
-snpeff_version: "4_3i"
-spades_version: 3.10.0
-vsearch_version: 2.4.0
-raxml_version: 8.2.9
-raxml_makefile: Makefile.AVX.PTHREADS.gcc
-cellranger_version: 1.3.1
-vcftools_version: 0.1.14
-muscle_version: 3.8.31
-cdhit_version: 4.6.7
-mothur_version: 1.39.5
-bcl2fastq2_version: 2.19.1
-emboss_version: 6.6.0
-infernal_version: 1.1.2
-# python virtualenv
-mimodd_version: 0.1.7.3
-multiqc_version: 1.0
-cutadapt_version: 1.12
-macs2_version: 2.1.1.20160309
-qiime_version: 1.9.1
-gatk4_version: 4.0b2
-miso_version: 0.5.4
-# bds version
-bds_version: 0.99999g
-bds_config:
-  tmpDir: /tmp
-
-# perl
-biotradis_version: 1.3.3
-bioperl_version: 1.007001
-# extra packages
-stack_version: 1.2.0
-nodejs_version: v6.9.1
-maven_version: 3.3.9
-tmux_version: 2.4
-hifive_version: 1.4.0
-ant_version: 1.10.1
-go_version: 1.8.3
-
-python3_executable: "python3"
-python3_virtualenv: "virtualenv"
-# Should match Python version used above, so site-packages 
-# in the virtualenv(s) can be found
-mimodd_python_version: "python3.5"
-
-# Compilation option: NO_TBB (Thread Building Blocks vs pthreads)
-# Valid values: 1 or 0
-bowtie2_notbb: 0
+# See:
+# bio_tools/defaults/main.yml
+# java/defaults/main.yml
+# R/defaults/main.yml
+# bds/defaults/main.yml
+# lmod/defaults/main.yml
+# lmod_etc/defaults/main.yml
+# extra/defaults/main.yml

--- a/group_vars/bio
+++ b/group_vars/bio
@@ -54,7 +54,7 @@ cutadapt_version: 1.12
 macs2_version: 2.1.1.20160309
 qiime_version: 1.9.1
 gatk4_version: 4.0b2
-
+miso_version: 0.5.4
 # bds version
 bds_version: 0.99999g
 bds_config:

--- a/group_vars/common
+++ b/group_vars/common
@@ -1,6 +1,2 @@
-rstudio_pro_key: ""
-# interactive
-rstudio_version: 1.0.143-amd64
-rstudio_pro_version: 1.0.143-amd64
-#shiny_version: 1.5.1.834-amd64
-shiny_version: 1.5.3.838-amd64
+# These variables have moved to:
+# interactive/defaults/main.yml

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -1,0 +1,2 @@
+---
+galaxy_info:

--- a/roles/R/defaults/main.yml
+++ b/roles/R/defaults/main.yml
@@ -1,0 +1,5 @@
+---
+r_base_mirror: "https://cran.csiro.au"
+r_base_version: 3.4.0
+# r_lib_path: "lib64/R/library"
+r_lib_path: "lib/R/library"

--- a/roles/R/templates/sw-module.lua.j2
+++ b/roles/R/templates/sw-module.lua.j2
@@ -9,19 +9,6 @@ local base = "{{ item.base }}"
 local base = pathJoin("{{ apps_dir }}", "{{ item.dir }}")
 {% endif %}
 
-{% if item.sik is defined %}
-load("STAR/{{ star_version  }}",
-     "subread/{{ subread_version }}",
-     "picard/{{ picard_version }}",
-     "fastqc/{{ fastqc_version }}",
-     "qualimap/{{ qualimap_version }}",
-     "samtools/{{ samtools_version }}",
-     "multiqc/{{ multiqc_version }}",
-     "java/{{ java_oracle_version }}",
-     "BigDataScript/{{ bds_version }}"
-    )
-{% endif %}
-
 {% if item.java is defined %}
 load("java/{{ java_oracle_version }}")
 {% endif %}

--- a/roles/bds/defaults/main.yml
+++ b/roles/bds/defaults/main.yml
@@ -1,7 +1,8 @@
 ---
-
-is_slurm_cluster: false
+bds_version: 0.99999g
 
 bds_tmpDir: "/tmp"
 bds_cluster_wrapper_dir: "{{ apps_dir }}/BigDataScript-{{ bds_version }}/clusterGenericSLURM"
 bds_default_memory: -1
+
+is_slurm_cluster: false

--- a/roles/bds/tasks/bds.yml
+++ b/roles/bds/tasks/bds.yml
@@ -25,7 +25,7 @@
   shell: export JAVA_HOME={{ apps_dir }}/jdk1.{{ jdk_major }}.0_{{ jdk_minor }}; cd {{ source_dir }}/BigDataScript-{{ version }}/; ./scripts/install.sh
   args:
     creates: "{{ local_home }}/.bds/bds"
-  when: java_tar.stat.isdir 
+  when: java_tar.stat.isdir is defined and java_tar.stat.isdir
 
 - name: build BigDataScript {{ version }} with java_local
   tags: bds

--- a/roles/bio_tools/defaults/main.yml
+++ b/roles/bio_tools/defaults/main.yml
@@ -1,7 +1,4 @@
 ---
-
-hifive_version: 1.4.0
-
 python3_executable: "python3"
 python3_virtualenv: "virtualenv"
 python3_pythonpath: ""
@@ -17,3 +14,49 @@ python2_pythonpath: ""
 # Compilation option: NO_TBB (Thread Building Blocks vs pthreads)
 # Valid values: 1 or 0
 bowtie2_notbb: 0
+
+# bio_tools versions
+star_version: 2.5.2b
+bwa_version: v0.7.15
+bowtie2_version: v2.3.2
+htslib_version: 1.4.1
+samtools_version: 1.4.1
+bcftools_version: 1.4.1
+subread_version: 1.5.2
+picard_version: 2.9.0
+gatk_version: 3.7
+fastqc_version: 0.11.5
+freebayes_version: 1.1.0
+vcflib_version: master
+sratoolkit_version: 2.8.0
+rnasik_version: 1.4.7
+qualimap_version: v2.2.1
+seqtk_version: v1.2
+igv_version: 2.3.94
+bedtools2_version: 2.25.0
+blast_version: 2.6.0
+smalt_version: 0.7.6
+snpeff_version: "4_3i"
+spades_version: 3.10.0
+vsearch_version: 2.4.0
+raxml_version: 8.2.9
+raxml_makefile: Makefile.AVX.PTHREADS.gcc
+cellranger_version: 1.3.1
+vcftools_version: 0.1.14
+muscle_version: 3.8.31
+cdhit_version: 4.6.7
+mothur_version: 1.39.5
+bcl2fastq2_version: 2.19.1
+emboss_version: 6.6.0
+#infernal_version: 1.1.2
+# python virtualenv
+mimodd_version: 0.1.7.3
+multiqc_version: 1.0
+cutadapt_version: 1.12
+macs2_version: 2.1.1.20160309
+qiime_version: 1.9.1
+hifive_version: 1.4.0
+
+# perl
+biotradis_version: 1.3.3
+bioperl_version: 1.007001

--- a/roles/bio_tools/tasks/bioperl.yml
+++ b/roles/bio_tools/tasks/bioperl.yml
@@ -7,6 +7,7 @@
     state: directory
     owner: "{{ main_guy }}"
   become: yes
+  become_user: "{{ main_guy }}"
 
 - name: Install Bio::Perl as a module
   tags: bioperl
@@ -27,6 +28,7 @@
     mode: 0755
     owner: "{{ main_guy }}"
   become: yes
+  become_user: "{{ main_guy }}"
 
 - name: bioperl {{ version }} module definition
   tags: bioperl
@@ -36,6 +38,7 @@
     owner: "{{ main_guy }}" 
     mode: 0644
   become: yes
+  become_user: "{{ main_guy }}"
   with_items:
     - dir: 'bioperl-{{ version }}'
       perl_path: 'lib/perl5'

--- a/roles/bio_tools/tasks/cellranger.yml
+++ b/roles/bio_tools/tasks/cellranger.yml
@@ -2,14 +2,14 @@
 
 
 - name: check cellranger-{{ version }}.tar.gz exists
-  local_action: stat path="{{ playbook_dir }}/tarballs/cellranger-{{ version }}.tar.gz"
+  local_action: stat path="{{ tarballs_path }}/cellranger-{{ version }}.tar.gz"
   register: c
 
   tags: cellranger
 
 - name: copy local cellranger-{{ version }}.tar.gz file
   copy:
-    src: "{{ playbook_dir }}/tarballs/cellranger-{{ version }}.tar.gz"
+    src: "{{ tarballs_path }}/cellranger-{{ version }}.tar.gz"
     dest: "{{ source_dir }}/cellranger-{{ version }}.tar.gz"
   when: c.stat.exists
 

--- a/roles/bio_tools/tasks/conda-package.yml
+++ b/roles/bio_tools/tasks/conda-package.yml
@@ -1,0 +1,37 @@
+---
+
+# The variables 'package' and 'tags' must be passed to this task when it's
+# included, like:
+#
+# - include: conda-package.yml package=gatk4 version=4.0b2 tags=["gatk4"]
+
+- name: Create conda environment for {{ package }}={{ version }}
+  tags: always
+  shell: "{{ conda_bin }} create --prefix={{ apps_dir }}/{{ package }}-{{ version }} {{ package }}={{ version }}"
+  args:
+    creates: "{{ apps_dir }}/{{ package }}-{{ version }}"
+
+- name: Create {{ package }} module directory
+  tags: always
+  file:
+    dest: "{{ modules_bio }}/{{ package }}"
+    state: directory
+    mode: 0755
+
+- name: Create {{ package }}/{{ version }} module definition
+  tags: always
+  template:
+    src: conda-module.lua.j2
+    dest: "{{ modules_bio }}/{{ package }}/{{ version }}.lua"
+    owner: "{{ main_guy }}" 
+    mode: 0644
+  with_items:
+    - dir: '{{ package }}-{{ version }}'
+      help_text: 'This module loads {{ package }}'
+
+- name: Set permission of {{ apps_dir }}/{{ package }}-{{ version }}
+  tags: always
+  file:
+    dest: "{{ apps_dir }}/{{ package }}-{{ version }}"
+    state: directory
+    mode: 0755

--- a/roles/bio_tools/tasks/conda-package.yml
+++ b/roles/bio_tools/tasks/conda-package.yml
@@ -1,25 +1,23 @@
 ---
 
-# The variables 'package' and 'tags' must be passed to this task when it's
+# The variable 'package' and 'version' must be passed to this task when it's
 # included, like:
 #
-# - include: conda-package.yml package=gatk4 version=4.0b2 tags=["gatk4"]
+# - include_tasks: conda-package.yml package=gatk4 version={{ gatk4_version }}
+#   tags: gatk4
 
 - name: Create conda environment for {{ package }}={{ version }}
-  tags: always
   shell: "{{ conda_bin }} create --prefix={{ apps_dir }}/{{ package }}-{{ version }} {{ package }}={{ version }}"
   args:
     creates: "{{ apps_dir }}/{{ package }}-{{ version }}"
 
 - name: Create {{ package }} module directory
-  tags: always
   file:
     dest: "{{ modules_bio }}/{{ package }}"
     state: directory
     mode: 0755
 
 - name: Create {{ package }}/{{ version }} module definition
-  tags: always
   template:
     src: conda-module.lua.j2
     dest: "{{ modules_bio }}/{{ package }}/{{ version }}.lua"
@@ -30,7 +28,6 @@
       help_text: 'This module loads {{ package }}'
 
 - name: Set permission of {{ apps_dir }}/{{ package }}-{{ version }}
-  tags: always
   file:
     dest: "{{ apps_dir }}/{{ package }}-{{ version }}"
     state: directory

--- a/roles/bio_tools/tasks/conda-package.yml
+++ b/roles/bio_tools/tasks/conda-package.yml
@@ -1,34 +1,35 @@
 ---
 
-# The variable 'package' and 'version' must be passed to this task when it's
+# The variable 'module_name, 'conda_packages' (list) and 'version' must be passed to this task when it's
 # included, like:
 #
-# - include_tasks: conda-package.yml package=gatk4 version={{ gatk4_version }}
+# - include_tasks: conda-package.yml module_name=gatk4 conda_packages=['gatk4={{ gatk4_version }}'] version={{ gatk4_version }}
 #   tags: gatk4
 
-- name: Create conda environment for {{ package }}={{ version }}
-  shell: "{{ conda_bin }} create --prefix={{ apps_dir }}/{{ package }}-{{ version }} {{ package }}={{ version }}"
+- name: Create conda environment for {{ module_name }}={{ version }} & install packages
+  shell: "{{ conda_bin }} create --prefix={{ apps_dir }}/{{ module_name }}-{{ version }} {{ conda_packages|join(' ') }}"
   args:
-    creates: "{{ apps_dir }}/{{ package }}-{{ version }}"
+    creates: "{{ apps_dir }}/{{ module_name }}-{{ version }}"
+  # with_items: "{{ conda_packages }}"
 
-- name: Create {{ package }} module directory
+- name: Create {{ module_name }} module directory
   file:
-    dest: "{{ modules_bio }}/{{ package }}"
+    dest: "{{ modules_bio }}/{{ module_name }}"
     state: directory
     mode: 0755
 
-- name: Create {{ package }}/{{ version }} module definition
+- name: Create {{ module_name }}/{{ version }} module definition
   template:
     src: conda-module.lua.j2
-    dest: "{{ modules_bio }}/{{ package }}/{{ version }}.lua"
+    dest: "{{ modules_bio }}/{{ module_name }}/{{ version }}.lua"
     owner: "{{ main_guy }}" 
     mode: 0644
   with_items:
-    - dir: '{{ package }}-{{ version }}'
-      help_text: 'This module loads {{ package }}'
+    - dir: '{{ module_name }}-{{ version }}'
+      help_text: 'This module loads {{ module_name }}'
 
-- name: Set permission of {{ apps_dir }}/{{ package }}-{{ version }}
+- name: Set permission of {{ apps_dir }}/{{ module_name }}-{{ version }}
   file:
-    dest: "{{ apps_dir }}/{{ package }}-{{ version }}"
+    dest: "{{ apps_dir }}/{{ module_name }}-{{ version }}"
     state: directory
     mode: 0755

--- a/roles/bio_tools/tasks/conda.yml
+++ b/roles/bio_tools/tasks/conda.yml
@@ -1,0 +1,20 @@
+---
+
+- name: Download Miniconda
+  tags: conda
+  get_url:
+    url: https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh
+    dest: "{{ source_dir }}/Miniconda3-latest-Linux-x86_64.sh"
+
+- name: Install Miniconda
+  tags: conda
+  shell: "bash {{ source_dir }}/Miniconda3-latest-Linux-x86_64.sh -f -b -p {{ apps_dir }}/conda"
+
+- name: Add Conda channels
+  tags: conda
+  shell: "{{ conda_bin }} config --add channels {{ item }}"
+  with_items:
+    - defaults
+    - conda-forge
+    - bioconda
+    - r

--- a/roles/bio_tools/tasks/gatk.yml
+++ b/roles/bio_tools/tasks/gatk.yml
@@ -1,20 +1,20 @@
 ---
 
 - name: check GenomeAnalysisTK-{{ version }}.tar.bz2 exists
-  local_action: stat path="{{ playbook_dir }}/tarballs/GenomeAnalysisTK-{{ version }}.tar.bz2"
+  local_action: stat path="{{ tarballs_path }}/GenomeAnalysisTK-{{ version }}.tar.bz2"
   register: g
 
   tags: gatk
 
 - debug:
-    msg: "Skipping installation of GATK - tarballs/GenomeAnalysisTK-{{ version }}.tar.bz2 not found."
+    msg: "Skipping installation of GATK - {{ tarballs_path }}/GenomeAnalysisTK-{{ version }}.tar.bz2 not found."
   when: not g.stat.exists
 
   tags: gatk
 
 - name: copy local GenomeAnalysisTK-{{ version }}.tar.bz2 file
   copy:
-    src: "{{ playbook_dir }}/tarballs/GenomeAnalysisTK-{{ version }}.tar.bz2"
+    src: "{{ tarballs_path }}/GenomeAnalysisTK-{{ version }}.tar.bz2"
     dest: "{{ source_dir }}/GenomeAnalysisTK-{{ version }}.tar.bz2"
   when: g.stat.exists
 

--- a/roles/bio_tools/tasks/hifive.yml
+++ b/roles/bio_tools/tasks/hifive.yml
@@ -6,6 +6,10 @@
     name: hifive
     version: "{{ version }}"
     virtualenv: "{{ apps_dir }}/hifive-{{ version }}"
+    virtualenv_python: "{{ python2_executable }}"
+    virtualenv_command: "{{ python2_virtualenv }}"
+  environment:
+    PYTHONPATH: "{{ python2_pythonpath }}"
 
 - name: Set module permissions for hifive
   tags: hifive

--- a/roles/bio_tools/tasks/igv_fromzip.yml
+++ b/roles/bio_tools/tasks/igv_fromzip.yml
@@ -3,14 +3,14 @@
 # assumes you have tarbal downloaded
 #
 - name: check IGV-{{ version }}.zip exists
-  local_action: stat path="{{ playbook_dir }}/tarballs/IGV-{{ version }}.zip"
+  local_action: stat path="{{ tarballs_path }}/IGV-{{ version }}.zip"
   register: i
 
   tags: igv
 
 - name: copy IGV-{{ version }}.zip file
   copy:
-    src: "{{ playbook_dir }}/tarballs/IGV-{{ version }}.zip"
+    src: "{{ tarballs_path }}/IGV-{{ version }}.zip"
     dest: "{{ source_dir }}/IGV-{{ version }}.zip"
   when: i.stat.exists
 

--- a/roles/bio_tools/tasks/main.yml
+++ b/roles/bio_tools/tasks/main.yml
@@ -1,7 +1,7 @@
 ---
 - name: Find Python3 version
   tags: ["always", "python"]
-  command: python3 --version
+  command: "{{ python3_executable }} --version"
   register: python3_v_str
 
 - name: Debug find python3 version
@@ -16,7 +16,7 @@
 
 - name: Find Python2 version
   tags: ["always", "python"]
-  command: python --version
+  command: "{{ python2_executable }} --version"
   register: python2_v_str
 
 - name: Debug find python2 version

--- a/roles/bio_tools/tasks/main.yml
+++ b/roles/bio_tools/tasks/main.yml
@@ -55,7 +55,7 @@
 - include: smalt.yml version={{ smalt_version }}
   #- include: bcl2fastq2.yml version={{ bcl2fastq2_version }}
 - include: emboss.yml version={{ emboss_version }}
-# pythons
+# Python-based
 - include: mimodd.yml version={{ mimodd_version }}
 - include: multiqc.yml version={{ multiqc_version }}
 - include: cutadapt.yml version={{ cutadapt_version }}
@@ -73,10 +73,17 @@
 - include: muscle.yml version={{ muscle_version }}
 - include: cdhit.yml version={{ cdhit_version }}
 - include: mothur.yml version={{ mothur_version }}
-#- include: infernal.yml version={{ infernal_version }}#installation doesn't work
-# alsways keep those two at the bottom of the list as they tend to break during compilation
-- include: freebayes.yml version={{ freebayes_version }}
-- include: vcflib.yml version={{ vcflib_version }}
 - include: hifive.yml version={{ hifive_version }}
+#- include: infernal.yml version={{ infernal_version }} # broken ? replaced by bioconda version
 
-- include: conda-package.yml package=gatk4 version={{ gatk4_version }} tags=["gatk4"]
+# List of Bioconda packages available: https://bioconda.github.io/recipes.html
+- include_tasks: conda-package.yml package=gatk4 version={{ gatk4_version }}
+  tags: gatk4
+- include_tasks: conda-package.yml package=freebayes version={{ freebayes_version }}
+  tags: freebayes
+- include_tasks: conda-package.yml package=infernal version={{ infernal_version }}
+  tags: infernal
+
+# always install freebayes and vcflib last as they tend to break during compilation
+# - include: freebayes.yml version={{ freebayes_version }} # replaced by bioconda version
+- include: vcflib.yml version={{ vcflib_version }}

--- a/roles/bio_tools/tasks/main.yml
+++ b/roles/bio_tools/tasks/main.yml
@@ -29,6 +29,12 @@
   tags: ["always", "python"]
   set_fact: python2_version_major_minor="{{ python2_v_str.stderr.split()[1].rsplit('.', 1)[0] }}"
 
+- name: Set conda executable path
+  tags: ["always"]
+  set_fact: conda_bin={{ apps_dir }}/conda/bin/conda
+
+- include: conda.yml
+
 - include: star.yml version={{ star_version}}
 - include: bwa.yml version={{ bwa_version }} 
 - include: bowtie2.yml version={{ bowtie2_version }} 
@@ -72,3 +78,5 @@
 - include: freebayes.yml version={{ freebayes_version }}
 - include: vcflib.yml version={{ vcflib_version }}
 - include: hifive.yml version={{ hifive_version }}
+
+- include: conda-package.yml package=gatk4 version={{ gatk4_version }} tags=["gatk4"]

--- a/roles/bio_tools/tasks/main.yml
+++ b/roles/bio_tools/tasks/main.yml
@@ -77,12 +77,14 @@
 #- include: infernal.yml version={{ infernal_version }} # broken ? replaced by bioconda version
 
 # List of Bioconda packages available: https://bioconda.github.io/recipes.html
-- include_tasks: conda-package.yml package=gatk4 version={{ gatk4_version }}
+- include_tasks: conda-package.yml module_name=gatk4 conda_packages=['gatk4={{ gatk4_version }}'] version={{ gatk4_version }}
   tags: gatk4
-- include_tasks: conda-package.yml package=freebayes version={{ freebayes_version }}
+- include_tasks: conda-package.yml module_name=freebayes conda_packages=['freebayes={{ freebayes_version }}'] version={{ freebayes_version }}
   tags: freebayes
-- include_tasks: conda-package.yml package=infernal version={{ infernal_version }}
+- include_tasks: conda-package.yml module_name=infernal conda_packages=['infernal={{ infernal_version }}'] version={{ infernal_version }}
   tags: infernal
+- include_tasks: conda-package.yml module_name=miso conda_packages=['misopy={{ miso_version }}'] version={{ miso_version }}
+  tags: miso
 
 # always install freebayes and vcflib last as they tend to break during compilation
 # - include: freebayes.yml version={{ freebayes_version }} # replaced by bioconda version

--- a/roles/bio_tools/tasks/qiime.yml
+++ b/roles/bio_tools/tasks/qiime.yml
@@ -11,6 +11,8 @@
   with_items:
     - numpy
     - six
+    # More recent versions of this dependency seem to break qiime install (20-Dec-2017)
+    - "emperor==0.9.51"
 
   tags: qiime
 

--- a/roles/bio_tools/tasks/qiime.yml
+++ b/roles/bio_tools/tasks/qiime.yml
@@ -77,14 +77,14 @@
 
 # install usearch from pre-downloaded file
 - name: check usearch exists
-  local_action: stat path="{{ playbook_dir }}/tarballs/usearch5.2.236_i86linux32"
+  local_action: stat path="{{ tarballs_path }}/usearch5.2.236_i86linux32"
   register: u
 
   tags: qiime
 
 - name: copy local usearch
   copy:
-    src: "{{ playbook_dir }}/tarballs/usearch5.2.236_i86linux32"
+    src: "{{ tarballs_path }}/usearch5.2.236_i86linux32"
     dest: "{{ apps_dir }}/qiime-{{ version }}/bin/usearch"
     mode: 0755
 

--- a/roles/bio_tools/templates/conda-module.lua.j2
+++ b/roles/bio_tools/templates/conda-module.lua.j2
@@ -1,0 +1,38 @@
+help(
+[[
+{{ item.help_text }}
+]])
+
+{% if item.base is defined %}
+local base = "{{ item.base }}"
+{% else %}
+local base = pathJoin("{{ apps_dir }}", "{{ item.dir }}")
+{% endif %}
+
+local path = pathJoin(base, "bin")
+
+{% if item.append is defined %}
+  append_path("PATH", path)
+{% else %}
+  prepend_path("PATH", path)
+{% endif %}
+
+{% if item.perl_path is defined %}
+  prepend_path("PERL5LIB", pathJoin(base, "{{item.perl_path}}"))
+{% endif %}
+
+{% if item.python_path is defined %}
+  prepend_path("PYTHONPATH", pathJoin(base, "{{item.python_path}}"))
+{% endif %}
+
+{% for e in item.env|default([]) %}
+  setenv("{{e.name}}", "{{e.value}}")
+{% endfor %}
+
+{% if item.depend is defined %}
+  load({{ item.depend }})
+{% endif %}
+
+{% if item.msg is defined %}
+  LmodMessage("{{ item.msg }}")
+{% endif %}

--- a/roles/cephfs/tasks/main.yml
+++ b/roles/cephfs/tasks/main.yml
@@ -3,9 +3,11 @@
   tags: ['cephfs', 'storage']
   include_vars: "{{ item }}"
   with_first_found:
-    - "{{ private_vars_path }}/host_vars/{{ inventory_hostname }}/vault_cephfs.yml"
-    - "{{ private_vars_path }}/vars/vault_cephfs.yml"
-    # - "cephfs.yml"
+    - files:
+      - "{{ private_vars_path }}/host_vars/{{ inventory_hostname }}/vault_cephfs.yml"
+      - "{{ private_vars_path }}/vars/vault_cephfs.yml"
+      # - "vault_cephfs.yml"
+      skip: true
 
 - include: install.yml
 - include: configure.yml

--- a/roles/common/tasks/apt.yml
+++ b/roles/common/tasks/apt.yml
@@ -79,6 +79,7 @@
     - libxmu-dev
     - libglu1-mesa-dev
     - libcgal-dev
+    - libnetcdf-dev
     # RStudio deps
     - libgstreamer-plugins-base0.10-0
     - libgstreamer0.10-0

--- a/roles/common/tasks/apt.yml
+++ b/roles/common/tasks/apt.yml
@@ -18,6 +18,7 @@
     - make
     - cmake
     - unzip
+    - realpath
     # security
     - fail2ban
     # non essential, useful

--- a/roles/common/tasks/main.yml
+++ b/roles/common/tasks/main.yml
@@ -2,6 +2,7 @@
 - include: sh_is_bash.yml
 - include: sshd.yml
 - include: apt.yml
+- include: singularity-apt.yml
 - include: pip.yml
 - include: pip3.yml
 - include: email_setup.yml

--- a/roles/common/tasks/singularity-apt.yml
+++ b/roles/common/tasks/singularity-apt.yml
@@ -1,0 +1,29 @@
+---
+
+- name: Add NeuroDebian repo keys
+  tags: ['singularity']
+  apt_key:
+    keyserver: pool.sks-keyservers.net
+    id: "0xA5D32F012649A5A9"
+
+- name: Add the NeuroDebian data repo
+  tags: ['singularity']
+  apt_repository:
+    repo: "deb http://mirror.aarnet.edu.au/pub/neurodebian data main contrib non-free"
+    update_cache: no
+    state: present
+
+- name: Add the NeuroDebian {{ ansible_distribution_release }} repo
+  tags: ['singularity']
+  apt_repository:
+    repo: "deb http://mirror.aarnet.edu.au/pub/neurodebian {{ ansible_distribution_release }} main contrib non-free"
+    update_cache: yes
+    state: present
+
+- name: Install Singularity
+  tags: ['singularity']
+  apt:
+    pkg: "{{ item }}"
+  with_items:
+    - squashfs-tools
+    - singularity-container

--- a/roles/common/tasks/singularity-apt.yml
+++ b/roles/common/tasks/singularity-apt.yml
@@ -13,10 +13,12 @@
     update_cache: no
     state: present
 
-- name: Add the NeuroDebian {{ ansible_distribution_release }} repo
+- name: Add the NeuroDebian repo
   tags: ['singularity']
   apt_repository:
-    repo: "deb http://mirror.aarnet.edu.au/pub/neurodebian {{ ansible_distribution_release }} main contrib non-free"
+    # repo: "deb http://mirror.aarnet.edu.au/pub/neurodebian {{ ansible_distribution_release }} main contrib non-free"
+    # We force xenial even on early Ubuntu releases so we can get verson 2.4.x
+    repo: "deb http://mirror.aarnet.edu.au/pub/neurodebian xenial main contrib non-free"
     update_cache: yes
     state: present
 
@@ -24,6 +26,7 @@
   tags: ['singularity']
   apt:
     pkg: "{{ item }}"
+    state: latest
   with_items:
     - squashfs-tools
     - singularity-container

--- a/roles/data/defaults/main.yml
+++ b/roles/data/defaults/main.yml
@@ -1,0 +1,5 @@
+---
+# training data, mainly for biotraining server
+r_intro_version: gh-pages
+r_more_version: gh-pages
+r_de_analysis_version: gh-pages

--- a/roles/extras/defaults/main.yml
+++ b/roles/extras/defaults/main.yml
@@ -1,3 +1,8 @@
 ---
+stack_version: 1.2.0
+nodejs_version: v6.9.1
+maven_version: 3.3.9
+tmux_version: 2.4
+hifive_version: 1.4.0
 ant_version: 1.10.1
 go_version: 1.8.3

--- a/roles/extras/tasks/environment-script.yml
+++ b/roles/extras/tasks/environment-script.yml
@@ -3,6 +3,6 @@
   tags: environment
   template:
     src: bioansible_env.sh.j2
-    dest: "{{ modules_dir }}/bioansible_env.sh"
+    dest: "{{ bioansible_basepath }}/bioansible_env.sh"
     owner: "{{ main_guy }}"
     mode: 0644

--- a/roles/interactive/defaults/main.yml
+++ b/roles/interactive/defaults/main.yml
@@ -8,3 +8,7 @@ shiny_version: 1.5.3.838-amd64
 
 # You should keep this defined in an ansible-vault encrypted file
 rstudio_pro_key: ""
+
+# If nodejs is installed via the 'extras' role, the version defined
+# there should match this one
+nodejs_version: v6.9.1

--- a/roles/interactive/defaults/main.yml
+++ b/roles/interactive/defaults/main.yml
@@ -1,0 +1,10 @@
+---
+
+# interactive
+rstudio_version: 1.0.143-amd64
+rstudio_pro_version: 1.0.143-amd64
+#shiny_version: 1.5.1.834-amd64
+shiny_version: 1.5.3.838-amd64
+
+# You should keep this defined in an ansible-vault encrypted file
+rstudio_pro_key: ""

--- a/roles/java/tasks/oracle.yml
+++ b/roles/java/tasks/oracle.yml
@@ -3,14 +3,14 @@
 # assumes you have tarbal downloaded
 #
 - name: check jdk-{{ version }}-linux-x64.tar.gz exists
-  local_action: stat path="{{ playbook_dir }}/tarballs/jdk-{{ version }}-linux-x64.tar.gz"
+  local_action: stat path="{{ tarballs_path }}/jdk-{{ version }}-linux-x64.tar.gz"
   register: j
 
   tags: java_oracle
 
 - name: copy local jdk-{{ version }}-linux-x64.tar.gz file
   copy:
-    src: "{{ playbook_dir }}/tarballs/jdk-{{ version }}-linux-x64.tar.gz"
+    src: "{{ tarballs_path }}/jdk-{{ version }}-linux-x64.tar.gz"
     dest: "{{ source_dir }}/jdk-{{ version }}-linux-x64.tar.gz"
   when: j.stat.exists
 

--- a/roles/java/templates/sw-module.lua.j2
+++ b/roles/java/templates/sw-module.lua.j2
@@ -9,17 +9,6 @@ local base = "{{ item.base }}"
 local base = pathJoin("{{ apps_dir }}", "{{ item.dir }}")
 {% endif %}
 
-{% if item.sik is defined %}
-load("STAR/{{ star_version  }}",
-     "subread/{{ subread_version }}",
-     "picard/{{ picard_version }}",
-     "fastqc/{{ fastqc_version }}",
-     "qualimap/{{ qualimap_version }}",
-     "samtools/{{ samtools_version }}",
-     "BigDataScript/{{ bds_version }}"
-    )
-{% endif %}
-
 {% if item.java is defined %}
   prepend_path("JAVA_HOME",base)
   prepend_path("JAVA_ROOT",base)

--- a/roles/lmod/defaults/main.yml
+++ b/roles/lmod/defaults/main.yml
@@ -1,0 +1,2 @@
+---
+lmod_version: 7.3.9

--- a/roles/lmod_etc/defaults/main.yml
+++ b/roles/lmod_etc/defaults/main.yml
@@ -1,0 +1,2 @@
+---
+lmod_version: 7.3.9

--- a/roles/make_sw_guy/tasks/main.yml
+++ b/roles/make_sw_guy/tasks/main.yml
@@ -1,45 +1,53 @@
 ---
 # Make sw-installer guy and allowing him to install software
 - name: create {{ main_guy }} user
+  tags: sw_guy
   user:
     name: "{{ main_guy }}"
     shell: /bin/bash
     comment: "software install user"
 
+- name: set authorized key from file
   tags: sw_guy
-
-- name: set authorized key took from file
   authorized_key:
     user: "{{ main_guy }}"
     state: present
     key: "{{ main_guy_pubkey }}"
 
+- name: set authorized keys from private config
   tags: sw_guy
+  authorized_key:
+    user: "{{ main_guy }}"
+    state: present
+    key: "{{ lookup('file', item) }}"
+  with_fileglob: "{{ private_vars_path }}/public_keys/*.pub"
 
 #TODO check if this will work?
-  #- file:
+  #- name: Set bioansible_basepath permissions
+  #  tags: sw_guy
+  #  file:
   #    dest: "{{ bioansible_basepath }}"
   #    state: directory
   #    owner: "{{ sudo_guy }}"
   #    group: "{{ sudo_guy }}"
   #    mode: 0755
   #
-  #  tags: sw_guy
 
-- file:
+- name: Set {{ bioansible_basepath }}/software permissions
+  tags: sw_guy
+  file:
     dest: "{{ bioansible_basepath }}/software"
     state: directory
     owner: "{{ main_guy }}"
     group: "{{ main_guy }}"
     mode: 0755
 
+- name: Set {{ data_dir }} permissions
   tags: sw_guy
-
-- file:
+  file:
     dest: "{{ data_dir }}"
     state: directory
     owner: "{{ main_guy }}"
     group: "{{ main_guy }}"
     mode: 0755
 
-  tags: sw_guy

--- a/roles/user_auth/templates/krb5.conf
+++ b/roles/user_auth/templates/krb5.conf
@@ -31,6 +31,14 @@ AD.MONASH.EDU = AD.MONASH.EDU
 
 [appdefaults]
  pam = {
+   # minimum_uid should be > highest local account and < lowest LDAP account
+   # to allow local account to change their passwords.
+   # If present, also needs to be updated on the krb5 line in:
+   #  /etc/pam.d/common-auth
+   #  /etc/pam.d/common-session
+   #  /etc/pam.d/common-account
+   #  /etc/pam.d/common-password
+   minimum_uid = 10000
    debug = false
    ticket_lifetime = 36000
    renew_lifetime = 36000


### PR DESCRIPTION
This PR moves most of the variables from `group_vars/*` into role specific defaults at `{role}/defaults/main.yml`. This helps to make bio-ansible roles reusable for other playbook/inventory combination, including using bio-ansible roles via Ansible Galaxy. 

`group_vars/*` and `host_vars/*` in the playbook directory can be used to override the role defaults as usual.

The tarballs directory location is now configurable (this was also required to allow the roles to be used from another playbook/inventory outside the bio-ansible repo directory).