### PR TITLE
Fix igv install beyond 2.4.13

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,12 +10,15 @@ services:
 
 before_install:
   - pip install -U "ansible<2.5"
+  # Full build exceeds job timeout
   # - travis_wait 300 docker build -t bio-ansbile:latest -f docker/Dockerfile-local .
-  - travis_wait 300 docker build -t bio-ansbile:latest -f docker/Dockerfile-rnasik .
+  - travis_wait 300 docker build -t bio-ansbile:rnasik -f docker/Dockerfile-rnasik .
 
 script:
-  - ansible-playbook --syntax-check -c local -i hosts common.yml
-  - ansible-playbook --syntax-check -c local -i hosts bio.yml
-  - ansible-playbook --syntax-check -c local -i hosts interactive.yml
-  - ansible-playbook --syntax-check -c local -i hosts other.yml
-  - docker run -d bio-ansbile /bin/sh -c "source /etc/profile.d/lmod.sh; module --force try-load BigDataScript; module --force try-load RNAsik-pipe; RNAsik-pipe | grep 'RNAsik version'"
+  - ansible-playbook -vvv --syntax-check -c local -i hosts common.yml
+  - ansible-playbook -vvv --syntax-check -c local -i hosts bio.yml
+  - ansible-playbook -vvv --syntax-check -c local -i hosts interactive.yml
+  - ansible-playbook -vvv --syntax-check -c local -i hosts other.yml
+
+  # Functional tests of containers/tools
+  - docker run -d bio-ansbile:rnasik /bin/sh -c "source /etc/profile.d/lmod.sh; module --force try-load BigDataScript; module --force try-load RNAsik-pipe; RNAsik-pipe | grep 'RNAsik version'"

--- a/common.yml
+++ b/common.yml
@@ -4,13 +4,13 @@
   hosts: common
   remote_user: "{{ sudo_guy }}"
   roles:
-            # need to have no previlidged installer guy
-            - make_sw_guy
-            # apt-get installation
-            - common
-            # lmod installed in {{ bioansible_basepath }}/software/apps directory
-            - lmod_etc
-            # - user_auth
+    # need to have no previlidged installer guy
+    - make_sw_guy
+    # apt-get installation
+    - common
+    # lmod installed in {{ bioansible_basepath }}/software/apps directory
+    - lmod_etc
+    # - user_auth
 
   become: true
 
@@ -18,6 +18,6 @@
   hosts: gui
   remote_user: "{{ sudo_guy }}"
   roles:
-            - gui
+    - gui
 
   become: true

--- a/docker/Dockerfile-baseimage
+++ b/docker/Dockerfile-baseimage
@@ -1,12 +1,17 @@
-FROM ubuntu:16.04
+FROM ubuntu:18.04
 
 RUN apt-get -y update && \
-    DEBIAN_FRONTEND=noninteractive apt-get install -y locales locales-all && \
     DEBIAN_FRONTEND=noninteractive apt-get -y upgrade && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y locales locales-all && \
     localedef -i en_AU -c -f UTF-8 -A /usr/share/locale/locale.alias en_AU.UTF-8 && \
     dpkg-reconfigure --frontend=noninteractive locales && update-locale LANG=en_AU.UTF-8 && \
-    apt-get install -y python python3 python-pip python3-pip python-virtualenv python3-virtualenv && \
+    apt-get install -y python python3 python-pip python3-pip \
+                       python-virtualenv python3-virtualenv \
+                       build-essential git wget curl && \
     apt-get clean && \
-    rm -rf /var/lib/apt/lists/*
+    rm -rf /var/lib/apt/lists/* && \
+    pip install -U "pip==9.0.3" && \
+    pip install -U "ansible<2.5"
+
 
 CMD ["/bin/bash"]

--- a/docker/Dockerfile-bio-tags
+++ b/docker/Dockerfile-bio-tags
@@ -1,4 +1,4 @@
-FROM ubuntu:16.04
+FROM ubuntu:18.04
 
 ARG TASK_TAGS=seqtk
 
@@ -22,7 +22,7 @@ RUN mkdir -p /bioansible/software/apps
 # variables for nicer paths inside the Docker container
 ADD ./docker/host_vars/localhost /bio-ansible/host_vars/localhost
 
-RUN ansible-playbook -c local -i hosts bio.yml --tags $TASK_TAGS
+RUN ansible-playbook -vvv -c local -i hosts bio.yml --tags $TASK_TAGS
 
 RUN rm -rf /bio-ansbile && \
     apt-get clean && \

--- a/docker/Dockerfile-local
+++ b/docker/Dockerfile-local
@@ -1,4 +1,4 @@
-FROM ubuntu:16.04
+FROM ubuntu:18.04
 RUN apt-get -y update && \
     apt-get -y install python python3 python-pip python-virtualenv python3-pip python3-virtualenv git && \
     apt-get -y clean && \
@@ -18,12 +18,12 @@ RUN mkdir -p /bioansible/software/apps
 # variables for nicer paths inside the Docker container
 ADD ./docker/host_vars/localhost /bio-ansible/host_vars/localhost
 
-RUN ansible-playbook -c local -i hosts common.yml --tags apt && \
-    ansible-playbook -c local -i hosts common.yml --tags pip && \
-    ansible-playbook -c local -i hosts common.yml --skip-tags apt,pip && \
-    ansible-playbook -c local -i hosts bio.yml --tags r_base,r_extras && \
-    ansible-playbook -c local -i hosts bio.yml --tags blast && \
-    ansible-playbook -c local -i hosts bio.yml --skip-tags r_base,r_extras,blast && \
+RUN ansible-playbook -vvv -c local -i hosts common.yml --tags apt && \
+    ansible-playbook -vvv -c local -i hosts common.yml --tags pip,pip3 && \
+    ansible-playbook -vvv -c local -i hosts common.yml --skip-tags apt,pip,pip3 && \
+    ansible-playbook -vvv -c local -i hosts bio.yml --tags r_base,r_extras && \
+    ansible-playbook -vvv -c local -i hosts bio.yml --tags blast && \
+    ansible-playbook -vvv -c local -i hosts bio.yml --skip-tags r_base,r_extras,blast && \
     rm -rf /bio-ansbile && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*

--- a/docker/Dockerfile-repo
+++ b/docker/Dockerfile-repo
@@ -8,8 +8,8 @@ RUN apt-get -y update && \
 
 RUN git clone https://github.com/MonashBioinformaticsPlatform/bio-ansible.git && \
     cd bio-ansible && \
-    ansible-playbook -i hosts common.yml && \
-    ansible-playbook -i hosts bio.yml --skip-tags gatk,java_oracle,cell_ranger && \
+    ansible-playbook -vvv -i hosts common.yml && \
+    ansible-playbook -vvv -i hosts bio.yml --skip-tags gatk,java_oracle,cell_ranger && \
     rm -rf /bio-ansible && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*

--- a/docker/Dockerfile-rnasik
+++ b/docker/Dockerfile-rnasik
@@ -22,10 +22,10 @@ RUN mkdir -p /bioansible/software/modules
 RUN mkdir -p /bioansible/software/source
 RUN mkdir -p /bioansible/software/apps
 
-RUN ansible-playbook -c local -i hosts common.yml --tags lmod_etc,environment && \
-    ansible-playbook -c local -i hosts bio.yml --tags lmod && \
-    ansible-playbook -c local -i hosts bio.yml --tags bds && \
-    ansible-playbook -c local -i hosts bio.yml --tags rnasik,star,subread,samtools,htslib,bedtools,picard,qualimap,fastqc,multiqc,bwa,hisat2 && \
+RUN ansible-playbook -vvv -c local -i hosts common.yml --tags lmod_etc,environment && \
+    ansible-playbook -vvv -c local -i hosts bio.yml --tags lmod && \
+    ansible-playbook -vvv -c local -i hosts bio.yml --tags bds && \
+    ansible-playbook -vvv -c local -i hosts bio.yml --tags rnasik,star,subread,samtools,htslib,bedtools,picard,qualimap,fastqc,multiqc,bwa,hisat2 && \
     rm -rf /bio-ansible && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*

--- a/roles/bio_tools/tasks/cutadapt.yml
+++ b/roles/bio_tools/tasks/cutadapt.yml
@@ -5,7 +5,7 @@
     name: cutadapt
     version: "v{{ version }}"
     virtualenv: "{{ apps_dir }}/cutadapt-{{ version }}"
-    virtualenv_python: "{{ python3_executable }}"
+    virtualenv_python: "{{ python2_executable }}"
 
   tags: cutadapt
 

--- a/roles/bio_tools/tasks/emboss.yml
+++ b/roles/bio_tools/tasks/emboss.yml
@@ -1,37 +1,46 @@
 ---
 
-- name: download emboss package {{ version }}
-  get_url:
-    url: ftp://emboss.open-bio.org/pub/EMBOSS/EMBOSS-{{ version }}.tar.gz
-    timeout: 30
-    dest: "{{ source_dir }}/EMBOSS-{{ version }}.tar.gz"
+# EMBOSS FTP server returns "425 Security: Bad IP connecting" using get_url
+#- name: download emboss package {{ version }}
+#  tags: emboss
+#  get_url:
+#    url: ftp://emboss.open-bio.org/pub/EMBOSS/EMBOSS-{{ version }}.tar.gz
+#    timeout: 30
+#    dest: "{{ source_dir }}/EMBOSS-{{ version }}.tar.gz"
 
+
+- name: download emboss package {{ version }} (wget to workaround fussy FTP server)
   tags: emboss
+  shell: wget -c -O "{{ source_dir }}/EMBOSS-{{ version }}.tar.gz" "ftp://emboss.open-bio.org/pub/EMBOSS/EMBOSS-{{ version }}.tar.gz"
+  args:
+    creates: "{{ source_dir }}/EMBOSS-{{ version }}.tar.gz"
+
 
 - name: uncompress emboss {{ version }}
+  tags: emboss
   unarchive:
       src: "{{ source_dir }}/EMBOSS-{{ version }}.tar.gz"
       dest: "{{ source_dir }}"
       copy: no
 
-  tags: emboss
-
 - name: build emboss {{ version }}
+  tags: emboss
   shell: cd {{ source_dir }}/EMBOSS-{{ version }}; ./configure --prefix={{ apps_dir }}/emboss-{{ version }}; make; make install
   args:
     creates: "{{ source_dir }}/emboss-{{ version }}/bin/seqret"
 
-  tags: emboss
 
-- file:
+- name: Set EMBOSS module dir permissions
+  tags: emboss
+  file:
     dest: "{{ modules_bio }}/emboss"
     state: directory
     mode: 0755
 
-  tags: emboss
 
 - name: emboss {{ version }} module definition
-  template: 
+  tags: emboss
+  template:
     src: sw-module.lua.j2 
     dest: "{{ modules_bio }}/emboss/{{ version }}.lua"
     owner: "{{ main_guy }}" 
@@ -40,34 +49,31 @@
     - dir: 'emboss-{{ version }}'
       help_text: 'This module loads the EMBOSS bioinformatics tools'
 
+- name: Set EMBOSS app dir permissions
   tags: emboss
-
-- file:
+  file:
     dest: "{{ apps_dir }}/emboss-{{ version }}"
     state: directory
     mode: 0755
 
-  tags: emboss
-
 - name: setting register for emboss {{ version }}
+  tags: emboss
   stat:
     path: "{{ apps_dir }}/emboss-{{ version }}/bin/seqret"
   register: s
 
-  tags: emboss
 
 - name: removing emboss {{ version }} source directory
+  tags: emboss
   file:
     dest: "{{ source_dir }}/emboss-{{ version }}"
     state: absent
   when: "del_src and s.stat.exists"
 
-  tags: emboss
 
 - name: removing emboss {{ version }} tar file
+  tags: emboss
   file:
     dest: "{{ source_dir }}/emboss-{{ version }}.tar.gz"
     state: absent
   when: "del_src and s.stat.exists"
-
-  tags: emboss

--- a/roles/bio_tools/tasks/igv.yml
+++ b/roles/bio_tools/tasks/igv.yml
@@ -8,23 +8,23 @@
 
   tags: igv
 
-- name: download bcel-5.2 lib
-  get_url:
-    url: http://www.java2s.com/Code/JarDownload/bcel/bcel-5.2.jar.zip
-    dest: "{{ source_dir }}/igv-{{ version }}/extras/bcel-5.2.jar.zip"
+  #- name: download bcel-5.2 lib
+  #get_url:
+  #  url: http://www.java2s.com/Code/JarDownload/bcel/bcel-5.2.jar.zip
+  #  dest: "{{ source_dir }}/igv-{{ version }}/extras/bcel-5.2.jar.zip"
+  #
+  #tags: igv
 
-  tags: igv
-
-- name: uncompress bcel-5.2 lib
-  unarchive:
-    src: "{{ source_dir }}/igv-{{ version }}/extras/bcel-5.2.jar.zip"
-    dest: "{{ source_dir }}/igv-{{ version }}/extras"
-    copy: no
-
-  tags: igv
+  #- name: uncompress bcel-5.2 lib
+  #unarchive:
+  #  src: "{{ source_dir }}/igv-{{ version }}/extras/bcel-5.2.jar.zip"
+  #  dest: "{{ source_dir }}/igv-{{ version }}/extras"
+  #  copy: no
+  #
+  #tags: igv
 
 - name: check that /usr/bin/java exists
-  command: /usr/bin/java
+  command: /usr/bin/java -version
   register: java_local
   ignore_errors: true
 
@@ -38,7 +38,7 @@
   tags: igv
 
 - name: build igv {{ version }}
-  shell: export JAVA_HOME={{ apps_dir }}/jdk1.{{ jdk_major }}.0_{{ jdk_minor }}; cd {{ source_dir }}/igv-{{ version }}; ant
+  shell: export JAVA_HOME={{ apps_dir }}/jdk1.{{ jdk_major }}.0_{{ jdk_minor }}; cd {{ source_dir }}/igv-{{ version }}; ./gradlew createDist  # ant
   args:
     creates: "{{ source_dir }}/igv-{{ version }}/igv.jar"
   when: java_tar.stat.isdir 
@@ -46,27 +46,27 @@
   tags: igv
 
 - name: build igv {{ version }}
-  shell: cd {{ source_dir }}/igv-{{ version }}; ant
+  shell: cd {{ source_dir }}/igv-{{ version }}; ./gradlew createDist  # ant
   args:
     creates: "{{ source_dir }}/igv-{{ version }}/igv.jar"
   when: java_local and java_tar.stat.isdir is not defined
 
   tags: igv
 
-- name: build igv {{ version }}
-  shell: export JAVA_HOME={{ apps_dir }}/jdk1.{{ jdk_major }}.0_{{ jdk_minor }}; cd {{ source_dir }}/igv-{{ version }}; ant -lib {{ source_dir }}/igv-{{ version }}/extras -f scripts/build-tools.xml
+- name: build igv tools {{ version }}
+  shell: export JAVA_HOME={{ apps_dir }}/jdk1.{{ jdk_major }}.0_{{ jdk_minor }}; cd {{ source_dir }}/igv-{{ version }}; ./gradlew createToolsDist  # ant -lib {{ source_dir }}/igv-{{ version }}/extras -f scripts/build-tools.xml
   args:
     creates: "{{ source_dir }}/igv-{{ version }}/igvtools-dist/igvtools.jar"
   when: java_tar.stat.isdir 
-
+  
   tags: igv
 
-- name: build igv {{ version }}
-  shell: cd {{ source_dir }}/igv-{{ version }}; ant -lib {{ source_dir }}/igv-{{ version }}/extras -f scripts/build-tools.xml
+- name: build igv tools {{ version }}
+  shell: cd {{ source_dir }}/igv-{{ version }}; ./gradlew createToolsDist  # ant -lib {{ source_dir }}/igv-{{ version }}/extras -f scripts/build-tools.xml
   args:
     creates: "{{ source_dir }}/igv-{{ version }}/igvtools-dist/igvtools.jar"
   when: java_local and java_tar.stat.isdir is not defined
-
+  
   tags: igv
 
 - file:

--- a/roles/common/tasks/apt.yml
+++ b/roles/common/tasks/apt.yml
@@ -21,7 +21,6 @@
     - make
     - cmake
     - unzip
-    - realpath
     # security
     - fail2ban
     # non essential, useful
@@ -82,13 +81,9 @@
     - libglu1-mesa-dev
     - libcgal-dev
     - libnetcdf-dev
-    - libmariadb-client-lgpl-dev  # 16.04
     - libudunits2-0    # ChIPseeker
     - libudunits2-dev  # ChIPseeker
-    # - libmariadbclient-dev  # 14.04
     # RStudio deps
-    - libgstreamer-plugins-base0.10-0
-    - libgstreamer0.10-0
     - libjpeg62
     - liborc-0.4-0
     - libapparmor1
@@ -130,3 +125,48 @@
     - parallel
     - acl
     - qpdf
+
+- name: apt-get common dependencies (16.04+)
+  tags: apt
+  apt:
+    name: "{{ item }}"
+    state: present
+    autoremove: yes
+  with_items:
+    - libmariadb-client-lgpl-dev
+  when: ansible_distribution == 'Ubuntu' and ansible_lsb.major_release|int >= 16
+
+- name: apt-get common dependencies (14.04)
+  tags: apt
+  apt:
+    name: "{{ item }}"
+    state: present
+    autoremove: yes
+  with_items:
+    - libmariadbclient-dev
+  when: ansible_distribution == 'Ubuntu' and ansible_distribution_version == '14.04'
+
+- name: apt-get common dependencies (< 18.04)
+  tags: apt
+  apt:
+    name: "{{ item }}"
+    state: present
+    autoremove: yes
+  with_items:
+    - realpath
+    # Rstudio deps
+    - libgstreamer-plugins-base0.10-0
+    - libgstreamer0.10-0
+  when: ansible_distribution == 'Ubuntu' and ansible_lsb.major_release|int < 18
+
+- name: apt-get common dependencies (18.04)
+  tags: apt
+  apt:
+    name: "{{ item }}"
+    state: present
+    autoremove: yes
+  with_items:
+    - coreutils
+    # Rstudio deps
+    - libgstreamer-plugins-base1.0-0
+  when: ansible_distribution == 'Ubuntu' and ansible_distribution_version == '18.04'

--- a/roles/common/tasks/basemount.yml
+++ b/roles/common/tasks/basemount.yml
@@ -1,16 +1,18 @@
 ---
 
+- name: Add an Apt signing key for basemount
+  tags: ['basemount', 'apt']
+  apt_key:
+    id: 0A795D6FAEF4565D
+    # keyserver: keyserver.ubuntu.com
+    url: "https://bintray.com/user/downloadSubjectPublicKey?username=basespace"
+    state: present
+
 - name: Add repo for basemount
   tags: ['basemount', 'apt']
   apt_repository:
     repo: 'deb https://dl.bintray.com/basespace/BaseMount-DEB saucy main'
     filename: 'basemount'
-    state: present
-
-- name: Add an Apt signing key for basemount
-  tags: ['basemount', 'apt']
-  apt_key:
-    url: https://bintray.com/user/downloadSubjectPublicKey?username=basespace
     state: present
 
 - name: apt-get install basemount

--- a/roles/common/tasks/pip.yml
+++ b/roles/common/tasks/pip.yml
@@ -8,14 +8,17 @@
 #
 #  tags: pip
 
-- name: pip upgrade pip
-  pip:
-    name: pip
-    state: latest
-
+- name: apt-get install python-pip
   tags: pip
+  apt:
+    name: "{{ item }}"
+    state: present
+    autoremove: yes
+  with_items:
+    - python-pip
 
 - name: pip install python packages
+  tags: pip
   pip:
     name: "{{ item }}"
     state: present
@@ -35,6 +38,3 @@
     - pysam
     - nesoni
     - gffutils
-
-  tags: pip
-

--- a/roles/common/tasks/pip3.yml
+++ b/roles/common/tasks/pip3.yml
@@ -1,6 +1,16 @@
 ---
 
+- name: apt-get install python3-pip
+  tags: pip3
+  apt:
+    name: "{{ item }}"
+    state: present
+    autoremove: yes
+  with_items:
+    - python3-pip
+
 - name: pip3 install python packages
+  tags: pip3
   pip:
     name: "{{ item }}"
     state: present
@@ -20,6 +30,3 @@
     - notebook
     # other
     - awscli
-
-  tags: pip3
-


### PR DESCRIPTION
This is a placeholder PR so we don't forget to merge this branch when ready.

The IGV build process has changed in more recent version. The gradle build script in v2.4.13 doesn't include igvtools (probably a bug since it's in the docs), but the latest igv master does. Once they make a new release (eg 2.4.14), it should be fixed, we can merge this (changes in `roles/bio_tools/tasks/igv.yml`)